### PR TITLE
feat: implement unified PRISM scoring flow v1.2.1

### DIFF
--- a/docs/prism-unified-scoring-reference.md
+++ b/docs/prism-unified-scoring-reference.md
@@ -1,6 +1,6 @@
 # PRISM Unified Scoring – Implementation Reference (Design + API + Checklist)
 
-This reference consolidates the architecture, contracts, and operational requirements for the unified PRISM scoring flow. It’s structured as documentation for implementers and reviewers.
+This reference consolidates the architecture, contracts, and operational requirements for the unified PRISM scoring flow. It’s structured as documentation for implementers and reviewers. The shared scoring engine lives at `supabase/functions/_shared/scoreEngine.ts`.
 
 ## Frontend Integration (React)
 

--- a/supabase/functions/_shared/score-engine/__tests__/goldens/g1.input.json
+++ b/supabase/functions/_shared/score-engine/__tests__/goldens/g1.input.json
@@ -1,18 +1,29 @@
 {
-  "answers": [
+  "sessionId": "s",
+  "responses": [
     { "question_id": 1, "answer_value": 5 },
     { "question_id": 2, "answer_value": 4 },
     { "question_id": 3, "answer_value": 3 },
     { "question_id": 4, "answer_value": 2 }
   ],
-  "keyByQ": {
+  "scoringKey": {
     "1": { "tag": "Ti_S", "scale_type": "LIKERT_1_5" },
     "2": { "tag": "Ne_S", "scale_type": "LIKERT_1_5" },
     "3": { "tag": "Fi_S", "scale_type": "LIKERT_1_5" },
     "4": { "tag": "Se_S", "scale_type": "LIKERT_1_5" }
   },
-  "config": { "softmaxTemp": 1 },
-  "fc_scores": {
+  "config": {
+    "results_version": "v1.2.1",
+    "dim_thresholds": {"one":0, "two":0, "three":0},
+    "neuro_norms": {"mean":0, "sd":1},
+    "overlay_neuro_cut": 0,
+    "overlay_state_weights": {"stress":0, "time":0, "sleep":0, "focus":0},
+    "softmax_temp": 1,
+    "conf_raw_params": {"a":0.25, "b":0.35, "c":0.2},
+    "fit_band_thresholds": {"high_fit":10, "moderate_fit":5, "high_gap":0.2, "moderate_gap":0.1},
+    "fc_expected_min": 0
+  },
+  "fcFunctionScores": {
     "Ti": 60, "Ne": 40, "Fi": 20, "Fe": 0, "Ni": 0, "Se": 0, "Si": 0, "Te": 0
   }
 }

--- a/supabase/functions/_shared/score-engine/__tests__/goldens/g1.output.json
+++ b/supabase/functions/_shared/score-engine/__tests__/goldens/g1.output.json
@@ -1,90 +1,90 @@
 {
-  "profile": {
-    "type_code": "LII",
-    "type": "LII",
-    "base_func": "Ti",
-    "creative_func": "Ne",
-    "top_types": [
-      {
-        "code": "LII",
-        "share": 0.34074410797229066,
-        "score": 6.7
-      },
-      {
-        "code": "ILE",
-        "share": 0.25242944377581134,
-        "score": 6.3999999999999995
-      },
-      {
-        "code": "LSI",
-        "share": 0.12535275202330787,
-        "score": 5.7
-      }
-    ],
-    "strengths": {
-      "Ti": 4,
-      "Te": 0,
-      "Fi": 2,
-      "Fe": 0,
-      "Ni": 0,
-      "Ne": 3,
-      "Si": 0,
-      "Se": 1
+  "type_code": "LII",
+  "base_func": "Ti",
+  "creative_func": "Ne",
+  "top_types": [
+    {
+      "code": "LII",
+      "share": 0.34074410797229066
     },
-    "type_scores": {
-      "LIE": 2.0000000000000004,
-      "ILI": 2.0000000000000004,
-      "ESE": 2.0000000000000004,
-      "SEI": 2.0000000000000004,
-      "LII": 6.7,
-      "ILE": 6.3999999999999995,
-      "ESI": 4.1,
-      "SEE": 3.8000000000000003,
-      "LSE": 2.0000000000000004,
-      "SLI": 2.0000000000000004,
-      "EIE": 2.0000000000000004,
-      "IEI": 2.0000000000000004,
-      "LSI": 5.7,
-      "SLE": 4.8,
-      "EII": 5.1,
-      "IEE": 5.4
+    {
+      "code": "ILE",
+      "share": 0.25242944377581156
     },
-    "blocks": {
-      "likert": {},
-      "fc": {}
+    {
+      "code": "LSI",
+      "share": 0.1253527520233079
+    }
+  ],
+  "top_3_fits": [
+    {
+      "code": "LII",
+      "fit": 6.7,
+      "share": 0.34074410797229066
     },
-    "blocks_norm": {
-      "Core": 0,
-      "Critic": 0,
-      "Hidden": 0,
-      "Instinct": 0
+    {
+      "code": "ILE",
+      "fit": 6.4,
+      "share": 0.25242944377581156
     },
-    "overlay": "0",
-    "overlay_neuro": "0",
-    "overlay_state": "0",
-    "validity": {
-      "attention": 0,
-      "inconsistency": 0,
-      "sd_index": 0,
-      "duplicates": 0,
-      "state_modifiers": {},
-      "required_tag_gaps": []
-    },
-    "validity_status": "ok",
-    "confidence": "low",
-    "conf_calibrated": 0.3952,
-    "score_fit_raw": 6.7,
-    "score_fit_calibrated": 6.7,
-    "top_gap": 0.088,
-    "close_call": false,
-    "results_version": "v1.2.1",
-    "fc_source": "session",
-    "version": "v1.2.1"
+    {
+      "code": "LSI",
+      "fit": 5.7,
+      "share": 0.1253527520233079
+    }
+  ],
+  "score_fit_raw": 6.7,
+  "score_fit_calibrated": 6.7,
+  "fit_band": "moderate_fit",
+  "top_gap": 0.088,
+  "close_call": false,
+  "strengths": {
+    "Ti": 4,
+    "Te": 0,
+    "Fi": 2,
+    "Fe": 0,
+    "Ni": 0,
+    "Ne": 3,
+    "Si": 0,
+    "Se": 1
   },
-  "gap_to_second": 0.088,
-  "confidence_margin": 0.088,
-  "confidence_raw": 0.3952,
-  "confidence_calibrated": 0.3952,
-  "results_version": "v1.2.1",
-  "fc_source": "session"
+  "dimensions": {
+    "Ti": 0,
+    "Te": 0,
+    "Fi": 0,
+    "Fe": 0,
+    "Ni": 0,
+    "Ne": 0,
+    "Si": 0,
+    "Se": 0
+  },
+  "dims_highlights": {
+    "coherent": [],
+    "unique": []
+  },
+  "blocks_norm": {
+    "Core": 0,
+    "Critic": 0,
+    "Hidden": 0,
+    "Instinct": 0
+  },
+  "neuro_mean": 0,
+  "neuro_z": 0,
+  "overlay_neuro": "none",
+  "overlay_state": "none",
+  "state_index": 0,
+  "overlay": "0",
+  "validity_status": "valid",
+  "validity": {
+    "attention": 0,
+    "inconsistency": 0,
+    "sd_index": 0
+  },
+  "confidence": "Low",
+  "conf_raw": 0.3952,
+  "conf_calibrated": 0.3952,
+  "fc_answered_ct": 8,
+  "fc_coverage_bucket": "full",
+  "version": "v1.2.1",
+  "results_version": "v1.2.1"
 }

--- a/supabase/functions/_shared/score-engine/__tests__/goldens/g2.input.json
+++ b/supabase/functions/_shared/score-engine/__tests__/goldens/g2.input.json
@@ -1,18 +1,29 @@
 {
-  "answers": [
+  "sessionId": "s",
+  "responses": [
     { "question_id": 1, "answer_value": 2 },
     { "question_id": 2, "answer_value": 5 },
     { "question_id": 3, "answer_value": 4 },
     { "question_id": 4, "answer_value": 3 }
   ],
-  "keyByQ": {
+  "scoringKey": {
     "1": { "tag": "Ti_S", "scale_type": "LIKERT_1_5" },
     "2": { "tag": "Ne_S", "scale_type": "LIKERT_1_5" },
     "3": { "tag": "Fi_S", "scale_type": "LIKERT_1_5" },
     "4": { "tag": "Se_S", "scale_type": "LIKERT_1_5" }
   },
-  "config": { "softmaxTemp": 1 },
-  "fc_scores": {
+  "config": {
+    "results_version": "v1.2.1",
+    "dim_thresholds": {"one":0, "two":0, "three":0},
+    "neuro_norms": {"mean":0, "sd":1},
+    "overlay_neuro_cut": 0,
+    "overlay_state_weights": {"stress":0, "time":0, "sleep":0, "focus":0},
+    "softmax_temp": 1,
+    "conf_raw_params": {"a":0.25, "b":0.35, "c":0.2},
+    "fit_band_thresholds": {"high_fit":10, "moderate_fit":5, "high_gap":0.2, "moderate_gap":0.1},
+    "fc_expected_min": 0
+  },
+  "fcFunctionScores": {
     "Ti": 0, "Ne": 80, "Fi": 10, "Fe": 0, "Ni": 0, "Se": 10, "Si": 0, "Te": 0
   }
 }

--- a/supabase/functions/_shared/score-engine/__tests__/goldens/g2.output.json
+++ b/supabase/functions/_shared/score-engine/__tests__/goldens/g2.output.json
@@ -1,90 +1,90 @@
 {
-  "profile": {
-    "type_code": "IEE",
-    "type": "IEE",
-    "base_func": "Ne",
-    "creative_func": "Fi",
-    "top_types": [
-      {
-        "code": "IEE",
-        "share": 0.37751556794748914,
-        "score": 6.625
-      },
-      {
-        "code": "ILE",
-        "share": 0.20206952218773094,
-        "score": 6
-      },
-      {
-        "code": "EII",
-        "share": 0.19221447529976943,
-        "score": 5.949999999999999
-      }
-    ],
-    "strengths": {
-      "Ti": 1,
-      "Te": 0,
-      "Fi": 2.25,
-      "Fe": 0,
-      "Ni": 0,
-      "Ne": 4.5,
-      "Si": 0,
-      "Se": 1.75
+  "type_code": "IEE",
+  "base_func": "Ne",
+  "creative_func": "Fi",
+  "top_types": [
+    {
+      "code": "IEE",
+      "share": 0.377515567947489
     },
-    "type_scores": {
-      "LIE": 1.9000000000000001,
-      "ILI": 1.9000000000000001,
-      "ESE": 1.9000000000000001,
-      "SEI": 1.9000000000000001,
-      "LII": 4.949999999999999,
-      "ILE": 6,
-      "ESI": 4.575,
-      "SEE": 4.425,
-      "LSE": 1.9000000000000001,
-      "SLI": 1.9000000000000001,
-      "EIE": 1.9000000000000001,
-      "IEI": 1.9000000000000001,
-      "LSI": 3.575,
-      "SLE": 3.8,
-      "EII": 5.949999999999999,
-      "IEE": 6.625
+    {
+      "code": "ILE",
+      "share": 0.2020695221877309
     },
-    "blocks": {
-      "likert": {},
-      "fc": {}
+    {
+      "code": "EII",
+      "share": 0.19221447529976954
+    }
+  ],
+  "top_3_fits": [
+    {
+      "code": "IEE",
+      "fit": 6.625,
+      "share": 0.377515567947489
     },
-    "blocks_norm": {
-      "Core": 0,
-      "Critic": 0,
-      "Hidden": 0,
-      "Instinct": 0
+    {
+      "code": "ILE",
+      "fit": 6,
+      "share": 0.2020695221877309
     },
-    "overlay": "0",
-    "overlay_neuro": "0",
-    "overlay_state": "0",
-    "validity": {
-      "attention": 0,
-      "inconsistency": 0,
-      "sd_index": 0,
-      "duplicates": 0,
-      "state_modifiers": {},
-      "required_tag_gaps": []
-    },
-    "validity_status": "ok",
-    "confidence": "low",
-    "conf_calibrated": 0.4262,
-    "score_fit_raw": 6.625,
-    "score_fit_calibrated": 6.625,
-    "top_gap": 0.175,
-    "close_call": false,
-    "results_version": "v1.2.1",
-    "fc_source": "session",
-    "version": "v1.2.1"
+    {
+      "code": "EII",
+      "fit": 5.95,
+      "share": 0.19221447529976954
+    }
+  ],
+  "score_fit_raw": 6.625,
+  "score_fit_calibrated": 6.625,
+  "fit_band": "moderate_fit",
+  "top_gap": 0.175,
+  "close_call": false,
+  "strengths": {
+    "Ti": 1,
+    "Te": 0,
+    "Fi": 2.25,
+    "Fe": 0,
+    "Ni": 0,
+    "Ne": 4.5,
+    "Si": 0,
+    "Se": 1.75
   },
-  "gap_to_second": 0.175,
-  "confidence_margin": 0.175,
-  "confidence_raw": 0.4262,
-  "confidence_calibrated": 0.4262,
-  "results_version": "v1.2.1",
-  "fc_source": "session"
+  "dimensions": {
+    "Ti": 0,
+    "Te": 0,
+    "Fi": 0,
+    "Fe": 0,
+    "Ni": 0,
+    "Ne": 0,
+    "Si": 0,
+    "Se": 0
+  },
+  "dims_highlights": {
+    "coherent": [],
+    "unique": []
+  },
+  "blocks_norm": {
+    "Core": 0,
+    "Critic": 0,
+    "Hidden": 0,
+    "Instinct": 0
+  },
+  "neuro_mean": 0,
+  "neuro_z": 0,
+  "overlay_neuro": "none",
+  "overlay_state": "none",
+  "state_index": 0,
+  "overlay": "0",
+  "validity_status": "valid",
+  "validity": {
+    "attention": 0,
+    "inconsistency": 0,
+    "sd_index": 0
+  },
+  "confidence": "Low",
+  "conf_raw": 0.4262,
+  "conf_calibrated": 0.4262,
+  "fc_answered_ct": 8,
+  "fc_coverage_bucket": "full",
+  "version": "v1.2.1",
+  "results_version": "v1.2.1"
 }

--- a/supabase/functions/_shared/score-engine/__tests__/goldens/g3.input.json
+++ b/supabase/functions/_shared/score-engine/__tests__/goldens/g3.input.json
@@ -1,15 +1,26 @@
 {
-  "answers": [
+  "sessionId": "s",
+  "responses": [
     { "question_id": 1, "answer_value": 1 },
     { "question_id": 2, "answer_value": 2 },
     { "question_id": 3, "answer_value": 3 },
     { "question_id": 4, "answer_value": 4 }
   ],
-  "keyByQ": {
+  "scoringKey": {
     "1": { "tag": "Ti_S", "scale_type": "LIKERT_1_5" },
     "2": { "tag": "Ne_S", "scale_type": "LIKERT_1_5" },
     "3": { "tag": "Fi_S", "scale_type": "LIKERT_1_5" },
     "4": { "tag": "Se_S", "scale_type": "LIKERT_1_5" }
   },
-  "config": { "softmaxTemp": 1 }
+  "config": {
+    "results_version": "v1.2.1",
+    "dim_thresholds": {"one":0, "two":0, "three":0},
+    "neuro_norms": {"mean":0, "sd":1},
+    "overlay_neuro_cut": 0,
+    "overlay_state_weights": {"stress":0, "time":0, "sleep":0, "focus":0},
+    "softmax_temp": 1,
+    "conf_raw_params": {"a":0.25, "b":0.35, "c":0.2},
+    "fit_band_thresholds": {"high_fit":10, "moderate_fit":5, "high_gap":0.2, "moderate_gap":0.1},
+    "fc_expected_min": 0
+  }
 }

--- a/supabase/functions/_shared/score-engine/__tests__/goldens/g3.output.json
+++ b/supabase/functions/_shared/score-engine/__tests__/goldens/g3.output.json
@@ -1,90 +1,90 @@
 {
-  "profile": {
-    "type_code": "SEE",
-    "type": "SEE",
-    "base_func": "Se",
-    "creative_func": "Fi",
-    "top_types": [
-      {
-        "code": "SEE",
-        "share": 0.3407441079722905,
-        "score": 6.699999999999999
-      },
-      {
-        "code": "ESI",
-        "share": 0.25242944377581167,
-        "score": 6.4
-      },
-      {
-        "code": "SLE",
-        "share": 0.12535275202330795,
-        "score": 5.7
-      }
-    ],
-    "strengths": {
-      "Ti": 1,
-      "Te": 0,
-      "Fi": 3,
-      "Fe": 0,
-      "Ni": 0,
-      "Ne": 2,
-      "Si": 0,
-      "Se": 4
+  "type_code": "SEE",
+  "base_func": "Se",
+  "creative_func": "Fi",
+  "top_types": [
+    {
+      "code": "SEE",
+      "share": 0.34074410797229066
     },
-    "type_scores": {
-      "LIE": 2,
-      "ILI": 2,
-      "ESE": 2,
-      "SEI": 2,
-      "LII": 3.8,
-      "ILE": 4.1,
-      "ESI": 6.4,
-      "SEE": 6.699999999999999,
-      "LSE": 2,
-      "SLI": 2,
-      "EIE": 2,
-      "IEI": 2,
-      "LSI": 4.8,
-      "SLE": 5.7,
-      "EII": 5.3999999999999995,
-      "IEE": 5.1
+    {
+      "code": "ESI",
+      "share": 0.25242944377581156
     },
-    "blocks": {
-      "likert": {},
-      "fc": {}
+    {
+      "code": "SLE",
+      "share": 0.1253527520233079
+    }
+  ],
+  "top_3_fits": [
+    {
+      "code": "SEE",
+      "fit": 6.7,
+      "share": 0.34074410797229066
     },
-    "blocks_norm": {
-      "Core": 0,
-      "Critic": 0,
-      "Hidden": 0,
-      "Instinct": 0
+    {
+      "code": "ESI",
+      "fit": 6.4,
+      "share": 0.25242944377581156
     },
-    "overlay": "0",
-    "overlay_neuro": "0",
-    "overlay_state": "0",
-    "validity": {
-      "attention": 0,
-      "inconsistency": 0,
-      "sd_index": 0,
-      "duplicates": 0,
-      "state_modifiers": {},
-      "required_tag_gaps": []
-    },
-    "validity_status": "ok",
-    "confidence": "low",
-    "conf_calibrated": 0.3952,
-    "score_fit_raw": 6.699999999999999,
-    "score_fit_calibrated": 6.699999999999999,
-    "top_gap": 0.088,
-    "close_call": false,
-    "results_version": "v1.2.1",
-    "fc_source": "none",
-    "version": "v1.2.1"
+    {
+      "code": "SLE",
+      "fit": 5.7,
+      "share": 0.1253527520233079
+    }
+  ],
+  "score_fit_raw": 6.7,
+  "score_fit_calibrated": 6.7,
+  "fit_band": "moderate_fit",
+  "top_gap": 0.088,
+  "close_call": false,
+  "strengths": {
+    "Ti": 1,
+    "Te": 0,
+    "Fi": 3,
+    "Fe": 0,
+    "Ni": 0,
+    "Ne": 2,
+    "Si": 0,
+    "Se": 4
   },
-  "gap_to_second": 0.088,
-  "confidence_margin": 0.088,
-  "confidence_raw": 0.3952,
-  "confidence_calibrated": 0.3952,
-  "results_version": "v1.2.1",
-  "fc_source": "none"
+  "dimensions": {
+    "Ti": 0,
+    "Te": 0,
+    "Fi": 0,
+    "Fe": 0,
+    "Ni": 0,
+    "Ne": 0,
+    "Si": 0,
+    "Se": 0
+  },
+  "dims_highlights": {
+    "coherent": [],
+    "unique": []
+  },
+  "blocks_norm": {
+    "Core": 0,
+    "Critic": 0,
+    "Hidden": 0,
+    "Instinct": 0
+  },
+  "neuro_mean": 0,
+  "neuro_z": 0,
+  "overlay_neuro": "none",
+  "overlay_state": "none",
+  "state_index": 0,
+  "overlay": "0",
+  "validity_status": "valid",
+  "validity": {
+    "attention": 0,
+    "inconsistency": 0,
+    "sd_index": 0
+  },
+  "confidence": "Low",
+  "conf_raw": 0.3952,
+  "conf_calibrated": 0.3952,
+  "fc_answered_ct": 0,
+  "fc_coverage_bucket": "full",
+  "version": "v1.2.1",
+  "results_version": "v1.2.1"
 }

--- a/supabase/functions/_shared/score-engine/__tests__/goldens/g4.input.json
+++ b/supabase/functions/_shared/score-engine/__tests__/goldens/g4.input.json
@@ -1,18 +1,29 @@
 {
-  "answers": [
+  "sessionId": "s",
+  "responses": [
     { "question_id": 1, "answer_value": 3 },
     { "question_id": 2, "answer_value": 3 },
     { "question_id": 3, "answer_value": 3 },
     { "question_id": 4, "answer_value": 3 }
   ],
-  "keyByQ": {
+  "scoringKey": {
     "1": { "tag": "Ti_S", "scale_type": "LIKERT_1_5" },
     "2": { "tag": "Ne_S", "scale_type": "LIKERT_1_5" },
     "3": { "tag": "Fi_S", "scale_type": "LIKERT_1_5" },
     "4": { "tag": "Se_S", "scale_type": "LIKERT_1_5" }
   },
-  "config": { "softmaxTemp": 1 },
-  "fc_scores": {
+  "config": {
+    "results_version": "v1.2.1",
+    "dim_thresholds": {"one":0, "two":0, "three":0},
+    "neuro_norms": {"mean":0, "sd":1},
+    "overlay_neuro_cut": 0,
+    "overlay_state_weights": {"stress":0, "time":0, "sleep":0, "focus":0},
+    "softmax_temp": 1,
+    "conf_raw_params": {"a":0.25, "b":0.35, "c":0.2},
+    "fit_band_thresholds": {"high_fit":10, "moderate_fit":5, "high_gap":0.2, "moderate_gap":0.1},
+    "fc_expected_min": 0
+  },
+  "fcFunctionScores": {
     "Te": 70, "Si": 30, "Ti": 0, "Ne": 0, "Fi": 0, "Fe": 0, "Ni": 0, "Se": 0
   }
 }

--- a/supabase/functions/_shared/score-engine/__tests__/goldens/g4.output.json
+++ b/supabase/functions/_shared/score-engine/__tests__/goldens/g4.output.json
@@ -1,90 +1,90 @@
 {
-  "profile": {
-    "type_code": "LII",
-    "type": "LII",
-    "base_func": "Ti",
-    "creative_func": "Ne",
-    "top_types": [
-      {
-        "code": "LII",
-        "share": 0.0898441470035404,
-        "score": 3.6500000000000004
-      },
-      {
-        "code": "ILE",
-        "share": 0.0898441470035404,
-        "score": 3.6500000000000004
-      },
-      {
-        "code": "EII",
-        "share": 0.0898441470035404,
-        "score": 3.6500000000000004
-      }
-    ],
-    "strengths": {
-      "Ti": 1.5,
-      "Te": 1.75,
-      "Fi": 1.5,
-      "Fe": 0,
-      "Ni": 0,
-      "Ne": 1.5,
-      "Si": 0.75,
-      "Se": 1.5
+  "type_code": "LII",
+  "base_func": "Ti",
+  "creative_func": "Ne",
+  "top_types": [
+    {
+      "code": "LII",
+      "share": 0.08984414700354038
     },
-    "type_scores": {
-      "LIE": 3.0999999999999996,
-      "ILI": 2.575,
-      "ESE": 2.075,
-      "SEI": 2.3,
-      "LII": 3.6500000000000004,
-      "ILE": 3.6500000000000004,
-      "ESI": 3.65,
-      "SEE": 3.65,
-      "LSE": 3.4749999999999996,
-      "SLI": 3.175,
-      "EIE": 1.7000000000000004,
-      "IEI": 1.7000000000000004,
-      "LSI": 3.65,
-      "SLE": 3.65,
-      "EII": 3.6500000000000004,
-      "IEE": 3.6500000000000004
+    {
+      "code": "ILE",
+      "share": 0.08984414700354038
     },
-    "blocks": {
-      "likert": {},
-      "fc": {}
+    {
+      "code": "ESI",
+      "share": 0.08984414700354038
+    }
+  ],
+  "top_3_fits": [
+    {
+      "code": "LII",
+      "fit": 3.65,
+      "share": 0.08984414700354038
     },
-    "blocks_norm": {
-      "Core": 0,
-      "Critic": 0,
-      "Hidden": 0,
-      "Instinct": 0
+    {
+      "code": "ILE",
+      "fit": 3.65,
+      "share": 0.08984414700354038
     },
-    "overlay": "0",
-    "overlay_neuro": "0",
-    "overlay_state": "0",
-    "validity": {
-      "attention": 0,
-      "inconsistency": 0,
-      "sd_index": 0,
-      "duplicates": 0,
-      "state_modifiers": {},
-      "required_tag_gaps": []
-    },
-    "validity_status": "ok",
-    "confidence": "low",
-    "conf_calibrated": 0.3194,
-    "score_fit_raw": 3.6500000000000004,
-    "score_fit_calibrated": 3.6500000000000004,
-    "top_gap": 0,
-    "close_call": true,
-    "results_version": "v1.2.1",
-    "fc_source": "session",
-    "version": "v1.2.1"
+    {
+      "code": "ESI",
+      "fit": 3.65,
+      "share": 0.08984414700354038
+    }
+  ],
+  "score_fit_raw": 3.65,
+  "score_fit_calibrated": 3.65,
+  "fit_band": "low_fit",
+  "top_gap": 0,
+  "close_call": true,
+  "strengths": {
+    "Ti": 1.5,
+    "Te": 1.75,
+    "Fi": 1.5,
+    "Fe": 0,
+    "Ni": 0,
+    "Ne": 1.5,
+    "Si": 0.75,
+    "Se": 1.5
   },
-  "gap_to_second": 0,
-  "confidence_margin": 0,
-  "confidence_raw": 0.3194,
-  "confidence_calibrated": 0.3194,
-  "results_version": "v1.2.1",
-  "fc_source": "session"
+  "dimensions": {
+    "Ti": 0,
+    "Te": 0,
+    "Fi": 0,
+    "Fe": 0,
+    "Ni": 0,
+    "Ne": 0,
+    "Si": 0,
+    "Se": 0
+  },
+  "dims_highlights": {
+    "coherent": [],
+    "unique": []
+  },
+  "blocks_norm": {
+    "Core": 0,
+    "Critic": 0,
+    "Hidden": 0,
+    "Instinct": 0
+  },
+  "neuro_mean": 0,
+  "neuro_z": 0,
+  "overlay_neuro": "none",
+  "overlay_state": "none",
+  "state_index": 0,
+  "overlay": "0",
+  "validity_status": "valid",
+  "validity": {
+    "attention": 0,
+    "inconsistency": 0,
+    "sd_index": 0
+  },
+  "confidence": "Low",
+  "conf_raw": 0.3194,
+  "conf_calibrated": 0.3194,
+  "fc_answered_ct": 8,
+  "fc_coverage_bucket": "full",
+  "version": "v1.2.1",
+  "results_version": "v1.2.1"
 }

--- a/supabase/functions/_shared/score-engine/__tests__/goldens/g5.input.json
+++ b/supabase/functions/_shared/score-engine/__tests__/goldens/g5.input.json
@@ -1,15 +1,26 @@
 {
-  "answers": [
+  "sessionId": "s",
+  "responses": [
     { "question_id": 1, "answer_value": 2 },
     { "question_id": 2, "answer_value": 2 },
     { "question_id": 3, "answer_value": 5 },
     { "question_id": 4, "answer_value": 1 }
   ],
-  "keyByQ": {
+  "scoringKey": {
     "1": { "tag": "Ti_S", "scale_type": "LIKERT_1_5" },
     "2": { "tag": "Ne_S", "scale_type": "LIKERT_1_5" },
     "3": { "tag": "Fi_S", "scale_type": "LIKERT_1_5" },
     "4": { "tag": "Se_S", "scale_type": "LIKERT_1_5" }
   },
-  "config": { "softmaxTemp": 1 }
+  "config": {
+    "results_version": "v1.2.1",
+    "dim_thresholds": {"one":0, "two":0, "three":0},
+    "neuro_norms": {"mean":0, "sd":1},
+    "overlay_neuro_cut": 0,
+    "overlay_state_weights": {"stress":0, "time":0, "sleep":0, "focus":0},
+    "softmax_temp": 1,
+    "conf_raw_params": {"a":0.25, "b":0.35, "c":0.2},
+    "fit_band_thresholds": {"high_fit":10, "moderate_fit":5, "high_gap":0.2, "moderate_gap":0.1},
+    "fc_expected_min": 0
+  }
 }

--- a/supabase/functions/_shared/score-engine/__tests__/goldens/g5.output.json
+++ b/supabase/functions/_shared/score-engine/__tests__/goldens/g5.output.json
@@ -1,90 +1,90 @@
 {
-  "profile": {
-    "type_code": "EII",
-    "type": "EII",
-    "base_func": "Fi",
-    "creative_func": "Ne",
-    "top_types": [
-      {
-        "code": "EII",
-        "share": 0.39574044767369554,
-        "score": 7.000000000000001
-      },
-      {
-        "code": "ESI",
-        "share": 0.2400287148024994,
-        "score": 6.500000000000001
-      },
-      {
-        "code": "IEE",
-        "share": 0.16089605915628669,
-        "score": 6.1000000000000005
-      }
-    ],
-    "strengths": {
-      "Ti": 2,
-      "Te": 0,
-      "Fi": 5,
-      "Fe": 0,
-      "Ni": 0,
-      "Ne": 2,
-      "Si": 0,
-      "Se": 1
+  "type_code": "EII",
+  "base_func": "Fi",
+  "creative_func": "Ne",
+  "top_types": [
+    {
+      "code": "EII",
+      "share": 0.39574044767369565
     },
-    "type_scores": {
-      "LIE": 1.9999999999999998,
-      "ILI": 1.9999999999999998,
-      "ESE": 1.9999999999999998,
-      "SEI": 1.9999999999999998,
-      "LII": 4.6000000000000005,
-      "ILE": 4.6000000000000005,
-      "ESI": 6.500000000000001,
-      "SEE": 5.3,
-      "LSE": 1.9999999999999998,
-      "SLI": 1.9999999999999998,
-      "EIE": 1.9999999999999998,
-      "IEI": 1.9999999999999998,
-      "LSI": 4.1,
-      "SLE": 3.8,
-      "EII": 7.000000000000001,
-      "IEE": 6.1000000000000005
+    {
+      "code": "ESI",
+      "share": 0.24002871480249952
     },
-    "blocks": {
-      "likert": {},
-      "fc": {}
+    {
+      "code": "IEE",
+      "share": 0.16089605915628677
+    }
+  ],
+  "top_3_fits": [
+    {
+      "code": "EII",
+      "fit": 7,
+      "share": 0.39574044767369565
     },
-    "blocks_norm": {
-      "Core": 0,
-      "Critic": 0,
-      "Hidden": 0,
-      "Instinct": 0
+    {
+      "code": "ESI",
+      "fit": 6.5,
+      "share": 0.24002871480249952
     },
-    "overlay": "0",
-    "overlay_neuro": "0",
-    "overlay_state": "0",
-    "validity": {
-      "attention": 0,
-      "inconsistency": 0,
-      "sd_index": 0,
-      "duplicates": 0,
-      "state_modifiers": {},
-      "required_tag_gaps": []
-    },
-    "validity_status": "ok",
-    "confidence": "low",
-    "conf_calibrated": 0.4223,
-    "score_fit_raw": 7.000000000000001,
-    "score_fit_calibrated": 7.000000000000001,
-    "top_gap": 0.156,
-    "close_call": false,
-    "results_version": "v1.2.1",
-    "fc_source": "none",
-    "version": "v1.2.1"
+    {
+      "code": "IEE",
+      "fit": 6.1,
+      "share": 0.16089605915628677
+    }
+  ],
+  "score_fit_raw": 7,
+  "score_fit_calibrated": 7,
+  "fit_band": "moderate_fit",
+  "top_gap": 0.156,
+  "close_call": false,
+  "strengths": {
+    "Ti": 2,
+    "Te": 0,
+    "Fi": 5,
+    "Fe": 0,
+    "Ni": 0,
+    "Ne": 2,
+    "Si": 0,
+    "Se": 1
   },
-  "gap_to_second": 0.156,
-  "confidence_margin": 0.156,
-  "confidence_raw": 0.4223,
-  "confidence_calibrated": 0.4223,
-  "results_version": "v1.2.1",
-  "fc_source": "none"
+  "dimensions": {
+    "Ti": 0,
+    "Te": 0,
+    "Fi": 0,
+    "Fe": 0,
+    "Ni": 0,
+    "Ne": 0,
+    "Si": 0,
+    "Se": 0
+  },
+  "dims_highlights": {
+    "coherent": [],
+    "unique": []
+  },
+  "blocks_norm": {
+    "Core": 0,
+    "Critic": 0,
+    "Hidden": 0,
+    "Instinct": 0
+  },
+  "neuro_mean": 0,
+  "neuro_z": 0,
+  "overlay_neuro": "none",
+  "overlay_state": "none",
+  "state_index": 0,
+  "overlay": "0",
+  "validity_status": "valid",
+  "validity": {
+    "attention": 0,
+    "inconsistency": 0,
+    "sd_index": 0
+  },
+  "confidence": "Low",
+  "conf_raw": 0.4223,
+  "conf_calibrated": 0.4223,
+  "fc_answered_ct": 0,
+  "fc_coverage_bucket": "full",
+  "version": "v1.2.1",
+  "results_version": "v1.2.1"
 }

--- a/supabase/functions/_shared/score-engine/__tests__/goldens/g6.input.json
+++ b/supabase/functions/_shared/score-engine/__tests__/goldens/g6.input.json
@@ -1,18 +1,29 @@
 {
-  "answers": [
+  "sessionId": "s",
+  "responses": [
     { "question_id": 1, "answer_value": 4 },
     { "question_id": 2, "answer_value": 4 },
     { "question_id": 3, "answer_value": 4 },
     { "question_id": 4, "answer_value": 4 }
   ],
-  "keyByQ": {
+  "scoringKey": {
     "1": { "tag": "Ti_S", "scale_type": "LIKERT_1_5" },
     "2": { "tag": "Ne_S", "scale_type": "LIKERT_1_5" },
     "3": { "tag": "Fi_S", "scale_type": "LIKERT_1_5" },
     "4": { "tag": "Se_S", "scale_type": "LIKERT_1_5" }
   },
-  "config": { "softmaxTemp": 1 },
-  "fc_scores": {
+  "config": {
+    "results_version": "v1.2.1",
+    "dim_thresholds": {"one":0, "two":0, "three":0},
+    "neuro_norms": {"mean":0, "sd":1},
+    "overlay_neuro_cut": 0,
+    "overlay_state_weights": {"stress":0, "time":0, "sleep":0, "focus":0},
+    "softmax_temp": 1,
+    "conf_raw_params": {"a":0.25, "b":0.35, "c":0.2},
+    "fit_band_thresholds": {"high_fit":10, "moderate_fit":5, "high_gap":0.2, "moderate_gap":0.1},
+    "fc_expected_min": 0
+  },
+  "fcFunctionScores": {
     "Ti": 50, "Te": 50, "Ne": 0, "Fi": 0, "Fe": 0, "Ni": 0, "Si": 0, "Se": 0
   }
 }

--- a/supabase/functions/_shared/score-engine/__tests__/goldens/g6.output.json
+++ b/supabase/functions/_shared/score-engine/__tests__/goldens/g6.output.json
@@ -1,90 +1,90 @@
 {
-  "profile": {
-    "type_code": "LII",
-    "type": "LII",
-    "base_func": "Ti",
-    "creative_func": "Ne",
-    "top_types": [
-      {
-        "code": "LII",
-        "share": 0.19208482823161468,
-        "score": 5.7
-      },
-      {
-        "code": "LSI",
-        "share": 0.19208482823161452,
-        "score": 5.699999999999999
-      },
-      {
-        "code": "ILE",
-        "share": 0.13201784306199424,
-        "score": 5.325
-      }
-    ],
-    "strengths": {
-      "Ti": 3.25,
-      "Te": 1.25,
-      "Fi": 2,
-      "Fe": 0,
-      "Ni": 0,
-      "Ne": 2,
-      "Si": 0,
-      "Se": 2
+  "type_code": "LII",
+  "base_func": "Ti",
+  "creative_func": "Ne",
+  "top_types": [
+    {
+      "code": "LII",
+      "share": 0.19208482823161463
     },
-    "type_scores": {
-      "LIE": 3.0999999999999996,
-      "ILI": 2.7249999999999996,
-      "ESE": 2.1,
-      "SEI": 2.1,
-      "LII": 5.7,
-      "ILE": 5.325,
-      "ESI": 4.699999999999999,
-      "SEE": 4.699999999999999,
-      "LSE": 3.0999999999999996,
-      "SLI": 2.7249999999999996,
-      "EIE": 2.1,
-      "IEI": 2.1,
-      "LSI": 5.699999999999999,
-      "SLE": 5.324999999999999,
-      "EII": 4.7,
-      "IEE": 4.7
+    {
+      "code": "LSI",
+      "share": 0.19208482823161463
     },
-    "blocks": {
-      "likert": {},
-      "fc": {}
+    {
+      "code": "ILE",
+      "share": 0.13201784306199418
+    }
+  ],
+  "top_3_fits": [
+    {
+      "code": "LII",
+      "fit": 5.7,
+      "share": 0.19208482823161463
     },
-    "blocks_norm": {
-      "Core": 0,
-      "Critic": 0,
-      "Hidden": 0,
-      "Instinct": 0
+    {
+      "code": "LSI",
+      "fit": 5.7,
+      "share": 0.19208482823161463
     },
-    "overlay": "0",
-    "overlay_neuro": "0",
-    "overlay_state": "0",
-    "validity": {
-      "attention": 0,
-      "inconsistency": 0,
-      "sd_index": 0,
-      "duplicates": 0,
-      "state_modifiers": {},
-      "required_tag_gaps": []
-    },
-    "validity_status": "ok",
-    "confidence": "low",
-    "conf_calibrated": 0.3438,
-    "score_fit_raw": 5.7,
-    "score_fit_calibrated": 5.7,
-    "top_gap": 0,
-    "close_call": true,
-    "results_version": "v1.2.1",
-    "fc_source": "session",
-    "version": "v1.2.1"
+    {
+      "code": "ILE",
+      "fit": 5.325,
+      "share": 0.13201784306199418
+    }
+  ],
+  "score_fit_raw": 5.7,
+  "score_fit_calibrated": 5.7,
+  "fit_band": "moderate_fit",
+  "top_gap": 0,
+  "close_call": true,
+  "strengths": {
+    "Ti": 3.25,
+    "Te": 1.25,
+    "Fi": 2,
+    "Fe": 0,
+    "Ni": 0,
+    "Ne": 2,
+    "Si": 0,
+    "Se": 2
   },
-  "gap_to_second": 0,
-  "confidence_margin": 0,
-  "confidence_raw": 0.3438,
-  "confidence_calibrated": 0.3438,
-  "results_version": "v1.2.1",
-  "fc_source": "session"
+  "dimensions": {
+    "Ti": 0,
+    "Te": 0,
+    "Fi": 0,
+    "Fe": 0,
+    "Ni": 0,
+    "Ne": 0,
+    "Si": 0,
+    "Se": 0
+  },
+  "dims_highlights": {
+    "coherent": [],
+    "unique": []
+  },
+  "blocks_norm": {
+    "Core": 0,
+    "Critic": 0,
+    "Hidden": 0,
+    "Instinct": 0
+  },
+  "neuro_mean": 0,
+  "neuro_z": 0,
+  "overlay_neuro": "none",
+  "overlay_state": "none",
+  "state_index": 0,
+  "overlay": "0",
+  "validity_status": "valid",
+  "validity": {
+    "attention": 0,
+    "inconsistency": 0,
+    "sd_index": 0
+  },
+  "confidence": "Low",
+  "conf_raw": 0.3438,
+  "conf_calibrated": 0.3438,
+  "fc_answered_ct": 8,
+  "fc_coverage_bucket": "full",
+  "version": "v1.2.1",
+  "results_version": "v1.2.1"
 }

--- a/supabase/functions/_shared/score-engine/__tests__/score-engine.test.ts
+++ b/supabase/functions/_shared/score-engine/__tests__/score-engine.test.ts
@@ -2,22 +2,17 @@ import { test } from "node:test";
 import assert from "node:assert";
 import { readFileSync, readdirSync } from "fs";
 import path from "path";
-import { scoreAssessment, TYPE_MAP } from "../index.ts";
+import { scoreAssessment } from "../index.ts";
 
 const goldDir = path.join(import.meta.dirname, "goldens");
 const pairs = readdirSync(goldDir)
-  .filter(f => f.endsWith('.input.json'))
-  .map(f => f.replace('.input.json',''));
+  .filter((f) => f.endsWith('.input.json'))
+  .map((f) => f.replace('.input.json', ''));
 
 for (const name of pairs) {
   test(`parity:${name}`, () => {
     const input = JSON.parse(readFileSync(path.join(goldDir, `${name}.input.json`), 'utf8'));
     const expected = JSON.parse(readFileSync(path.join(goldDir, `${name}.output.json`), 'utf8'));
-    if (!expected.profile.base_func) {
-      const map = TYPE_MAP[expected.profile.type_code as keyof typeof TYPE_MAP];
-      expected.profile.base_func = map.base;
-      expected.profile.creative_func = map.creative;
-    }
     const result = scoreAssessment(input);
     assert.deepStrictEqual(result, expected);
   });
@@ -32,7 +27,7 @@ for (const name of pairs) {
 
 test('resumed session yields same final result', () => {
   const input = JSON.parse(readFileSync(path.join(goldDir, `g1.input.json`), 'utf8'));
-  const partial = { ...input, answers: input.answers.slice(0,2) };
+  const partial = { ...input, responses: input.responses.slice(0, 2) };
   // simulate early scoring with partial answers
   scoreAssessment(partial);
   const singleShot = scoreAssessment(input);
@@ -41,19 +36,30 @@ test('resumed session yields same final result', () => {
 });
 
 test('fc_map derives forced-choice strengths', () => {
+  const cfg = {
+    results_version: 'v1.2.1',
+    dim_thresholds: { one: 0, two: 0, three: 0 },
+    neuro_norms: { mean: 0, sd: 1 },
+    overlay_neuro_cut: 0,
+    overlay_state_weights: { stress: 0, time: 0, sleep: 0, focus: 0 },
+    softmax_temp: 1,
+    conf_raw_params: { a: 0.25, b: 0.35, c: 0.2 },
+    fit_band_thresholds: { high_fit: 10, moderate_fit: 5, high_gap: 0.2, moderate_gap: 0.1 },
+    fc_expected_min: 0,
+  };
   const input = {
-    answers: [
+    sessionId: 's',
+    responses: [
       { question_id: 1, answer_value: 'A' },
       { question_id: 2, answer_value: 'B' },
     ],
-    keyByQ: {
+    scoringKey: {
       '1': { scale_type: 'LIKERT_1_5', fc_map: { A: 'Ti', B: 'Te' } },
       '2': { scale_type: 'LIKERT_1_5', fc_map: { B: 'Fe' } },
     },
-    config: { softmaxTemp: 1 },
+    config: cfg,
   };
   const result = scoreAssessment(input as any);
-  assert.strictEqual(result.fc_source, 'derived');
-  assert(result.profile.strengths.Ti > 0);
-  assert(result.profile.strengths.Fe > 0);
+  assert(result.strengths.Ti > 0);
+  assert(result.strengths.Fe > 0);
 });

--- a/supabase/functions/_shared/scoreEngine.ts
+++ b/supabase/functions/_shared/scoreEngine.ts
@@ -1,327 +1,269 @@
-// supabase/functions/_shared/scoreEngine.ts
-// Pure scoring engine for PRISM assessments
-// Provides functional building blocks and an orchestrator used by edge functions
+// Unified PRISM scoring engine v1.2.1
+// Pure module with no side effects; can run in Node or Deno
 
 export type Func =
-  | "Ti" | "Te" | "Fi" | "Fe"
-  | "Ni" | "Ne" | "Si" | "Se";
+  | 'Ti' | 'Te' | 'Fi' | 'Fe'
+  | 'Ni' | 'Ne' | 'Si' | 'Se';
 
 export type Block =
-  | "base" | "creative" | "role" | "vulnerable"
-  | "mobilizing" | "suggestive" | "ignoring" | "demonstrative";
+  | 'base' | 'creative' | 'role' | 'vulnerable'
+  | 'mobilizing' | 'suggestive' | 'ignoring' | 'demonstrative';
 
 export type TypeCode =
-  | "LIE"|"ILI"|"ESE"|"SEI"|"LII"|"ILE"|"ESI"|"SEE"
-  | "LSE"|"SLI"|"EIE"|"IEI"|"LSI"|"SLE"|"EII"|"IEE";
+  | 'LIE'|'ILI'|'ESE'|'SEI'|'LII'|'ILE'|'ESI'|'SEE'
+  | 'LSE'|'SLI'|'EIE'|'IEI'|'LSI'|'SLE'|'EII'|'IEE';
 
-export interface AnswerRow {
-  question_id: number | string;
-  answer_value: unknown;
+export interface ResponseRow {
+  question_id: string | number;
+  answer_value: string | number;
 }
 
-export interface KeyRecord {
-  tag?: string | null;
-  fc_map?: Record<string,string> | null;
+export interface ScoringKeyRecord {
   scale_type: string;
   reverse_scored?: boolean;
+  tag?: string;
+  pair_group?: string | null;
+  social_desirability?: boolean;
+  fc_map?: Record<string, string> | null;
+  meta?: unknown;
 }
 
-export interface EngineConfig {
+export interface ProfileConfig {
+  results_version: string;
+  dim_thresholds: { one: number; two: number; three: number };
+  neuro_norms: { mean: number; sd: number };
+  overlay_neuro_cut: number;
+  overlay_state_weights: { stress: number; time: number; sleep: number; focus: number };
+  softmax_temp: number;
+  conf_raw_params: { a: number; b: number; c: number };
+  fit_band_thresholds: { high_fit: number; moderate_fit: number; high_gap: number; moderate_gap: number };
+  fc_expected_min: number;
   typePrototypes?: Record<TypeCode, Record<Func, Block>>;
-  softmaxTemp: number;
-  confRawParams?: { a: number; b: number; c: number };
-  resultsVersion?: string;
 }
 
-export interface EngineInput {
-  answers: AnswerRow[];
-  keyByQ: Record<string, KeyRecord>;
-  config: EngineConfig;
-  fc_scores?: Record<Func, number>;
+export interface ProfileInput {
+  sessionId: string;
+  responses: ResponseRow[];
+  scoringKey: Record<string, ScoringKeyRecord>;
+  config: ProfileConfig;
+  fcFunctionScores?: Record<string, number>; // 0-100 per function
+  partial?: boolean;
+  fc_expected?: number;
 }
 
-export interface EngineProfile {
+export interface ProfileResult {
   type_code: TypeCode;
-  type: TypeCode;
   base_func: Func;
   creative_func: Func;
-  top_types: Array<{ code: TypeCode; share: number; score: number }>;
-  strengths: Record<Func, number>;
-  type_scores: Record<TypeCode, number>;
-  blocks: { likert: Record<string, unknown>; fc: Record<string, unknown> };
-  blocks_norm: Record<string, number>;
-  overlay: string;
-  overlay_neuro: string;
-  overlay_state: string;
-  validity: Record<string, unknown>;
-  validity_status: string;
-  confidence: string;
-  conf_calibrated: number;
+  top_types: Array<{ code: TypeCode; share: number }>;
+  top_3_fits: Array<{ code: TypeCode; fit: number; share: number }>;
   score_fit_raw: number;
   score_fit_calibrated: number;
+  fit_band: string;
   top_gap: number;
   close_call: boolean;
-  results_version: string;
-  fc_source: "session" | "derived" | "none";
+  strengths: Record<Func, number>;
+  dimensions: Record<Func, number>;
+  dims_highlights: { coherent: string[]; unique: string[] };
+  blocks_norm: { Core: number; Critic: number; Hidden: number; Instinct: number };
+  neuro_mean: number;
+  neuro_z: number;
+  overlay_neuro: string;
+  overlay_state: string;
+  state_index: number;
+  overlay: string;
+  validity_status: string;
+  validity: { attention: number; inconsistency: number; sd_index: number; duplicates?: number };
+  confidence: 'High' | 'Moderate' | 'Low';
+  conf_raw: number;
+  conf_calibrated: number;
+  fc_answered_ct: number;
+  fc_coverage_bucket: string;
   version: string;
-}
-
-export interface EngineResult {
-  profile: EngineProfile;
-  gap_to_second: number;
-  confidence_margin: number;
-  confidence_raw: number;
-  confidence_calibrated: number;
   results_version: string;
-  fc_source: "session" | "derived" | "none";
 }
 
-export const FUNCS: Func[] = ["Ti","Te","Fi","Fe","Ni","Ne","Si","Se"];
+export const FUNCS: Func[] = ['Ti','Te','Fi','Fe','Ni','Ne','Si','Se'];
 
 export const TYPE_MAP: Record<TypeCode, { base: Func; creative: Func }> = {
-  LIE:{ base:"Te", creative:"Ni" }, ILI:{ base:"Ni", creative:"Te" },
-  ESE:{ base:"Fe", creative:"Si" }, SEI:{ base:"Si", creative:"Fe" },
-  LII:{ base:"Ti", creative:"Ne" }, ILE:{ base:"Ne", creative:"Ti" },
-  ESI:{ base:"Fi", creative:"Se" }, SEE:{ base:"Se", creative:"Fi" },
-  LSE:{ base:"Te", creative:"Si" }, SLI:{ base:"Si", creative:"Te" },
-  EIE:{ base:"Fe", creative:"Ni" }, IEI:{ base:"Ni", creative:"Fe" },
-  LSI:{ base:"Ti", creative:"Se" }, SLE:{ base:"Se", creative:"Ti" },
-  EII:{ base:"Fi", creative:"Ne" }, IEE:{ base:"Ne", creative:"Fi" }
+  LIE:{ base:'Te', creative:'Ni' }, ILI:{ base:'Ni', creative:'Te' },
+  ESE:{ base:'Fe', creative:'Si' }, SEI:{ base:'Si', creative:'Fe' },
+  LII:{ base:'Ti', creative:'Ne' }, ILE:{ base:'Ne', creative:'Ti' },
+  ESI:{ base:'Fi', creative:'Se' }, SEE:{ base:'Se', creative:'Fi' },
+  LSE:{ base:'Te', creative:'Si' }, SLI:{ base:'Si', creative:'Te' },
+  EIE:{ base:'Fe', creative:'Ni' }, IEI:{ base:'Ni', creative:'Fe' },
+  LSI:{ base:'Ti', creative:'Se' }, SLE:{ base:'Se', creative:'Ti' },
+  EII:{ base:'Fi', creative:'Ne' }, IEE:{ base:'Ne', creative:'Fi' }
 };
 
 export const FALLBACK_PROTOTYPES: Record<TypeCode, Record<Func, Block>> = {
-  LIE: { Te:"base", Ni:"creative", Se:"role", Fi:"vulnerable", Ti:"mobilizing", Ne:"suggestive", Si:"ignoring", Fe:"demonstrative" },
-  ILI: { Ni:"base", Te:"creative", Fi:"role", Se:"vulnerable", Ne:"mobilizing", Ti:"suggestive", Fe:"ignoring", Si:"demonstrative" },
-  ESE: { Fe:"base", Si:"creative", Ne:"role", Ti:"vulnerable", Fi:"mobilizing", Ni:"suggestive", Te:"ignoring", Se:"demonstrative" },
-  SEI: { Si:"base", Fe:"creative", Ti:"role", Ne:"vulnerable", Ni:"mobilizing", Fi:"suggestive", Se:"ignoring", Te:"demonstrative" },
-  LII: { Ti:"base", Ne:"creative", Ni:"role", Fe:"vulnerable", Te:"mobilizing", Si:"suggestive", Fi:"ignoring", Se:"demonstrative" },
-  ILE: { Ne:"base", Ti:"creative", Fe:"role", Ni:"vulnerable", Si:"mobilizing", Te:"suggestive", Se:"ignoring", Fi:"demonstrative" },
-  ESI: { Fi:"base", Se:"creative", Ni:"role", Te:"vulnerable", Fe:"mobilizing", Ne:"suggestive", Ti:"ignoring", Si:"demonstrative" },
-  SEE: { Se:"base", Fi:"creative", Te:"role", Ni:"vulnerable", Ne:"mobilizing", Fe:"suggestive", Si:"ignoring", Ti:"demonstrative" },
-  LSE: { Te:"base", Si:"creative", Se:"role", Fi:"vulnerable", Ti:"mobilizing", Ne:"suggestive", Ni:"ignoring", Fe:"demonstrative" },
-  SLI: { Si:"base", Te:"creative", Fi:"role", Se:"vulnerable", Ni:"mobilizing", Ti:"suggestive", Fe:"ignoring", Ne:"demonstrative" },
-  EIE: { Fe:"base", Ni:"creative", Ne:"role", Ti:"vulnerable", Fi:"mobilizing", Si:"suggestive", Te:"ignoring", Se:"demonstrative" },
-  IEI: { Ni:"base", Fe:"creative", Ti:"role", Ne:"vulnerable", Si:"mobilizing", Fi:"suggestive", Se:"ignoring", Te:"demonstrative" },
-  LSI: { Ti:"base", Se:"creative", Ni:"role", Fe:"vulnerable", Te:"mobilizing", Ne:"suggestive", Fi:"ignoring", Si:"demonstrative" },
-  SLE: { Se:"base", Ti:"creative", Fe:"role", Ni:"vulnerable", Ne:"mobilizing", Te:"suggestive", Si:"ignoring", Fi:"demonstrative" },
-  EII: { Fi:"base", Ne:"creative", Ni:"role", Te:"vulnerable", Fe:"mobilizing", Si:"suggestive", Se:"ignoring", Ti:"demonstrative" },
-  IEE: { Ne:"base", Fi:"creative", Te:"role", Ni:"vulnerable", Si:"mobilizing", Fe:"suggestive", Se:"ignoring", Ti:"demonstrative" }
+  LIE:{ Te:'base', Ni:'creative', Se:'role', Fi:'vulnerable', Ti:'mobilizing', Ne:'suggestive', Si:'ignoring', Fe:'demonstrative' },
+  ILI:{ Ni:'base', Te:'creative', Fi:'role', Se:'vulnerable', Ne:'mobilizing', Ti:'suggestive', Fe:'ignoring', Si:'demonstrative' },
+  ESE:{ Fe:'base', Si:'creative', Ne:'role', Ti:'vulnerable', Fi:'mobilizing', Ni:'suggestive', Te:'ignoring', Se:'demonstrative' },
+  SEI:{ Si:'base', Fe:'creative', Ti:'role', Ne:'vulnerable', Ni:'mobilizing', Fi:'suggestive', Se:'ignoring', Te:'demonstrative' },
+  LII:{ Ti:'base', Ne:'creative', Ni:'role', Fe:'vulnerable', Te:'mobilizing', Si:'suggestive', Fi:'ignoring', Se:'demonstrative' },
+  ILE:{ Ne:'base', Ti:'creative', Fe:'role', Ni:'vulnerable', Si:'mobilizing', Te:'suggestive', Se:'ignoring', Fi:'demonstrative' },
+  ESI:{ Fi:'base', Se:'creative', Ni:'role', Te:'vulnerable', Fe:'mobilizing', Ne:'suggestive', Ti:'ignoring', Si:'demonstrative' },
+  SEE:{ Se:'base', Fi:'creative', Te:'role', Ni:'vulnerable', Ne:'mobilizing', Fe:'suggestive', Si:'ignoring', Ti:'demonstrative' },
+  LSE:{ Te:'base', Si:'creative', Se:'role', Fi:'vulnerable', Ti:'mobilizing', Ne:'suggestive', Ni:'ignoring', Fe:'demonstrative' },
+  SLI:{ Si:'base', Te:'creative', Fi:'role', Se:'vulnerable', Ni:'mobilizing', Ti:'suggestive', Fe:'ignoring', Ne:'demonstrative' },
+  EIE:{ Fe:'base', Ni:'creative', Ne:'role', Ti:'vulnerable', Fi:'mobilizing', Si:'suggestive', Te:'ignoring', Se:'demonstrative' },
+  IEI:{ Ni:'base', Fe:'creative', Ti:'role', Ne:'vulnerable', Si:'mobilizing', Fi:'suggestive', Se:'ignoring', Te:'demonstrative' },
+  LSI:{ Ti:'base', Se:'creative', Ni:'role', Fe:'vulnerable', Te:'mobilizing', Ne:'suggestive', Fi:'ignoring', Si:'demonstrative' },
+  SLE:{ Se:'base', Ti:'creative', Fe:'role', Ni:'vulnerable', Ne:'mobilizing', Te:'suggestive', Si:'ignoring', Fi:'demonstrative' },
+  EII:{ Fi:'base', Ne:'creative', Ni:'role', Te:'vulnerable', Fe:'mobilizing', Si:'suggestive', Se:'ignoring', Ti:'demonstrative' },
+  IEE:{ Ne:'base', Fi:'creative', Te:'role', Ni:'vulnerable', Si:'mobilizing', Fe:'suggestive', Se:'ignoring', Ti:'demonstrative' }
 };
 
-const RESULTS_VERSION = "v1.2.1";
-
-// --- helper functions ------------------------------------------------------
-function parseNum(raw: unknown): number | null {
-  if (raw == null) return null;
-  if (typeof raw === "number" && Number.isFinite(raw)) return raw;
-  const s = String(raw);
-  const m = s.match(/^(\d+)/);
-  if (m) return Number(m[1]);
-  const L = s.toLowerCase().trim();
-  const map: Record<string, number> = {
-    "strongly disagree": 1, "disagree": 2, "neutral": 3, "agree": 4, "strongly agree": 5,
-    "never": 1, "rarely": 2, "sometimes": 3, "often": 4, "always": 5,
-    "very low": 1, "low": 2, "slightly low": 2, "moderate": 3, "slightly high": 4, "high": 4, "very high": 5
-  };
-  return map[L] ?? null;
-}
-
-function reverseOnNative(v: number, scale: string): number {
-  if (!Number.isFinite(v)) return v;
-  if (scale === "LIKERT_1_7" || scale === "STATE_1_7") return 8 - v;
-  if (scale === "LIKERT_1_5" || scale?.startsWith("CATEGORICAL") || scale === "FREQUENCY") return 6 - v;
-  return v;
-}
-
-function toCommon5(v: number, scale: string): number {
-  if (!Number.isFinite(v)) return 0;
-  if (scale === "LIKERT_1_5" || scale?.startsWith("CATEGORICAL") || scale === "FREQUENCY") return v;
-  if (scale === "LIKERT_1_7" || scale === "STATE_1_7") return 1 + (v - 1) * (4/6);
-  return v;
+// Helper functions ---------------------------------------------------------
+function parseNumber(v: string | number): number | null {
+  if (v === null || v === undefined) return null;
+  if (typeof v === 'number') return Number.isFinite(v) ? v : null;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
 }
 
 function softmax(scores: Record<string, number>, temp: number): Record<string, number> {
-  const exps = Object.values(scores).map(v => Math.exp(v / temp));
-  const sum = exps.reduce((a,b)=>a+b,0) || 1;
-  const entries = Object.keys(scores).map((k,i)=>[k, exps[i]/sum]);
-  return Object.fromEntries(entries);
-}
-
-function mean(arr: number[]): number {
-  if (!arr.length) return 0;
-  return arr.reduce((a,b)=>a+b,0)/arr.length;
-}
-
-// --- pipeline steps -------------------------------------------------------
-export function processResponses(input: EngineInput): {
-  strengths: Record<Func, number>;
-  fcSource: "session" | "derived" | "none";
-} {
-  const { answers, keyByQ, fc_scores } = input;
-  const likert: Record<Func, number[]> = {} as any;
-  const fcTallies: Record<Func, number> = {} as any;
-
-  for (const row of answers) {
-    const qid = String(row.question_id);
-    const rec = keyByQ[qid];
-    if (!rec) continue;
-    // 1) FC derivation must run even when answer_value is non-numeric
-    if (!fc_scores && rec.fc_map) {
-      const choice = rec.fc_map[String(row.answer_value)];
-      if (choice && FUNCS.includes(choice as Func)) {
-        const f = choice as Func;
-        fcTallies[f] = (fcTallies[f] || 0) + 1;
-      }
-    }
-    // 2) Likert handling (numeric only)
-    const raw = parseNum(row.answer_value);
-    if (raw != null) {
-      const v = toCommon5(rec.reverse_scored ? reverseOnNative(raw, rec.scale_type) : raw, rec.scale_type);
-      const tag = rec.tag || undefined;
-      if (tag?.endsWith("_S")) {
-        const f = tag.split("_")[0] as Func;
-        (likert[f] ||= []).push(v);
-      }
-    }
+  const vals = Object.values(scores);
+  const max = Math.max(...vals);
+  const exps: Record<string, number> = {};
+  let sum = 0;
+  for (const [k, v] of Object.entries(scores)) {
+    const e = Math.exp((v - max) / temp);
+    exps[k] = e;
+    sum += e;
   }
+  for (const k of Object.keys(exps)) exps[k] = exps[k] / sum;
+  return exps;
+}
 
-  let fcNorm: Record<Func, number> | undefined = fc_scores;
-  let fcSource: "session" | "derived" | "none" = "none";
+// Main engine --------------------------------------------------------------
+export function scoreAssessment(input: ProfileInput): ProfileResult {
+  const { responses, scoringKey, config, fcFunctionScores } = input;
+  const likert: Record<Func, { sum: number; count: number }> = {} as any;
+  const fcDerived: Record<Func, number> = {} as any;
+  let fcAnswered = 0;
 
-  if (fc_scores) {
-    fcSource = "session";
-  } else if (Object.keys(fcTallies).length) {
-    const max = Math.max(...Object.values(fcTallies));
-    fcNorm = {} as any;
-    for (const f of FUNCS) {
-      fcNorm[f] = max ? (fcTallies[f] || 0) / max * 100 : 0;
+  for (const r of responses) {
+    const key = scoringKey[String(r.question_id)];
+    if (!key) continue;
+    const val = parseNumber(r.answer_value);
+    if (val === null) continue;
+    if (key.reverse_scored) {
+      // assume 1-5 scale
+      const max = 5;
+      const min = 1;
+      const flipped = max + min - val;
+      r.answer_value = flipped;
     }
-    fcSource = "derived";
+    const tag = key.tag ? key.tag.substring(0,2) as Func : undefined;
+    if (tag && key.scale_type.startsWith('LIKERT')) {
+      const entry = likert[tag] || { sum: 0, count: 0 };
+      entry.sum += Number(r.answer_value);
+      entry.count += 1;
+      likert[tag] = entry;
+    }
+    if (!fcFunctionScores && key.fc_map) {
+      const f = key.fc_map[String(r.answer_value)] as Func | undefined;
+      if (f) {
+        fcDerived[f] = (fcDerived[f] || 0) + 1;
+        fcAnswered++;
+      }
+    }
   }
 
   const strengths: Record<Func, number> = {} as any;
-  for (const f of FUNCS) {
-    const lik = mean(likert[f] || []);
-    const fcScore = fcNorm ? (fcNorm[f] / 100) * 5 : 0;
-    strengths[f] = fcNorm ? 0.5 * lik + 0.5 * fcScore : lik;
+  let fcSource: 'session' | 'derived' | 'none' = 'none';
+  const fcNorm: Record<Func, number> = {} as any;
+  if (fcFunctionScores) {
+    fcSource = 'session';
+    for (const f of FUNCS) {
+      const score = fcFunctionScores[f] ?? 0;
+      fcNorm[f] = (score / 100) * 5;
+    }
+  } else if (Object.keys(fcDerived).length > 0) {
+    fcSource = 'derived';
+    const total = Object.values(fcDerived).reduce((a,b)=>a+b,0) || 1;
+    for (const f of FUNCS) fcNorm[f] = (fcDerived[f] || 0) / total * 5;
   }
 
-  return { strengths, fcSource };
-}
+  for (const f of FUNCS) {
+    const lik = likert[f] ? likert[f].sum / likert[f].count : 0;
+    const fc = fcNorm[f] || 0;
+    strengths[f] = fcSource === 'none' ? lik : 0.5 * lik + 0.5 * fc;
+  }
 
-export function computeTypeMatches(strengths: Record<Func, number>, protos: Record<TypeCode, Record<Func, Block>>) {
+  // Type matching
+  const prototypes = config.typePrototypes || FALLBACK_PROTOTYPES;
   const typeScores: Record<TypeCode, number> = {} as any;
   for (const code of Object.keys(TYPE_MAP) as TypeCode[]) {
-    const proto = protos[code];
+    const proto = prototypes[code];
     let score = 0;
     for (const f of FUNCS) {
-      const blk = proto[f];
-      const w = blk === "base" ? 1 : blk === "creative" ? 0.7 : 0.2;
+      const block = proto[f];
+      const w = block === 'base' ? 1 : block === 'creative' ? 0.7 : 0.2;
       score += w * strengths[f];
     }
-    typeScores[code] = score;
+    typeScores[code] = Number(score.toFixed(4));
   }
-  return typeScores;
-}
 
-export function calibrateFitScores(scores: Record<TypeCode, number>): Record<TypeCode, number> {
-  // placeholder for future calibration models
-  return scores;
-}
-
-export function computeTypeProbabilities(scores: Record<TypeCode, number>, temp: number) {
-  return softmax(scores, temp);
-}
-
-export function rankTypes(shares: Record<TypeCode, number>, scores: Record<TypeCode, number>) {
+  const shares = softmax(typeScores, config.softmax_temp || 1);
   const sorted = (Object.keys(shares) as TypeCode[]).sort((a,b)=>{
     const diff = shares[b] - shares[a];
-    if (Math.abs(diff) < 1e-9) return scores[b] - scores[a];
+    if (Math.abs(diff) < 1e-9) return typeScores[b] - typeScores[a];
     return diff;
   });
-  const top3 = sorted.slice(0,3).map(code => ({ code, share: shares[code], score: scores[code] }));
-  const gap = top3[0].share - (top3[1]?.share || 0);
-  const scoreGap = top3[0].score - (top3[1]?.score || 0);
-  return { top3, gap, scoreGap };
-}
+  const top3 = sorted.slice(0,3).map(code => ({ code, share: shares[code], fit: typeScores[code] }));
+  const top = top3[0];
+  const second = top3[1];
+  const shareGap = top.share - (second?.share ?? 0);
+  const scoreGap = top.fit - (second?.fit ?? 0);
 
-export function computeOverlays(): { overlay: string } {
-  return { overlay: "0" };
-}
+  const params = config.conf_raw_params;
+  const entropy = -Object.values(shares).reduce((s,p)=>s+(p>0?p*Math.log2(p):0),0);
+  const rawConf = 1 / (1 + Math.exp(-(params.a * scoreGap + params.b * shareGap - params.c * entropy)));
+  const conf_raw = Number(rawConf.toFixed(4));
+  const confidence = conf_raw >= 0.75 ? 'High' : conf_raw >= 0.55 ? 'Moderate' : 'Low';
 
-export function assessValidity(): { validity_status: string } {
-  return { validity_status: "ok" };
-}
+  const fit_band = top.fit >= config.fit_band_thresholds.high_fit
+    ? 'high_fit'
+    : top.fit >= config.fit_band_thresholds.moderate_fit
+      ? 'moderate_fit'
+      : 'low_fit';
+  const fc_answered_ct = fcFunctionScores ? Object.keys(fcFunctionScores).length : fcAnswered;
+  const coverage = fc_answered_ct >= (input.fc_expected ?? config.fc_expected_min) ? 'full' : 'low';
 
-export function computeConfidence(topScoreGap: number, shareGap: number, shares: Record<TypeCode, number>, params: { a: number; b: number; c: number }) {
-  const sortedShares = Object.values(shares).filter(v => v > 0);
-  const entropy = -sortedShares.reduce((s,p)=>s+p*Math.log2(p),0);
-  let raw = 1 / (1 + Math.exp(-(params.a * topScoreGap + params.b * shareGap - params.c * entropy)));
-  raw = Math.max(0, Math.min(1, raw));
-  const band = raw >= 0.8 ? "high" : raw >= 0.6 ? "med" : "low";
-  return { raw, band };
-}
-
-export function assembleProfileResult(
-  input: EngineInput,
-  strengths: Record<Func, number>,
-  typeScores: Record<TypeCode, number>,
-  top3: Array<{code:TypeCode;share:number;score:number}>,
-  gap: number,
-  conf: { raw:number; band:string },
-  fcSource: "session" | "derived" | "none"
-): EngineProfile {
-  const type = top3[0].code;
-  const base = TYPE_MAP[type].base;
-  const creative = TYPE_MAP[type].creative;
-  const resultsVersion = input.config.resultsVersion || RESULTS_VERSION;
-  const closeCall = gap < 0.05;
-  return {
-    type_code: type,
-    type: type,
-    base_func: base,
-    creative_func: creative,
-    top_types: top3,
-    strengths,
-    type_scores: typeScores,
-    blocks: { likert: {}, fc: {} },
-    blocks_norm: { Core:0, Critic:0, Hidden:0, Instinct:0 },
-    overlay: "0",
-    overlay_neuro: "0",
-    overlay_state: "0",
-    validity: { attention:0, inconsistency:0, sd_index:0, duplicates:0, state_modifiers:{}, required_tag_gaps:[] },
-    validity_status: "ok",
-    confidence: conf.band,
-    conf_calibrated: Number(conf.raw.toFixed(4)),
-    score_fit_raw: top3[0].score,
-    score_fit_calibrated: top3[0].score,
-    top_gap: Number(gap.toFixed(3)),
-    close_call: closeCall,
-    results_version: resultsVersion,
-    fc_source: fcSource,
-    version: resultsVersion,
+  const result: ProfileResult = {
+    type_code: top.code,
+    base_func: TYPE_MAP[top.code].base,
+    creative_func: TYPE_MAP[top.code].creative,
+    top_types: top3.map(t => ({ code: t.code, share: t.share })),
+    top_3_fits: top3.map(t => ({ code: t.code, fit: t.fit, share: t.share })),
+    score_fit_raw: top.fit,
+    score_fit_calibrated: top.fit,
+    fit_band,
+    top_gap: Number(shareGap.toFixed(3)),
+    close_call: shareGap < 0.05,
+    strengths: FUNCS.reduce((acc,f)=>{acc[f]=Number(strengths[f].toFixed(3));return acc;}, {} as Record<Func,number>),
+    dimensions: FUNCS.reduce((acc,f)=>{acc[f]=0;return acc;}, {} as Record<Func,number>),
+    dims_highlights:{ coherent: [], unique: [] },
+    blocks_norm:{ Core:0, Critic:0, Hidden:0, Instinct:0 },
+    neuro_mean:0,
+    neuro_z:0,
+    overlay_neuro:'none',
+    overlay_state:'none',
+    state_index:0,
+    overlay:'0',
+    validity_status:'valid',
+    validity:{ attention:0, inconsistency:0, sd_index:0 },
+    confidence,
+    conf_raw,
+    conf_calibrated: conf_raw,
+    fc_answered_ct,
+    fc_coverage_bucket: coverage,
+    version: config.results_version,
+    results_version: config.results_version,
   };
+
+  return result;
 }
-
-export function runScoreEngine(input: EngineInput): EngineResult {
-  const protos = input.config.typePrototypes || FALLBACK_PROTOTYPES;
-  const { strengths, fcSource } = processResponses(input);
-  const matches = computeTypeMatches(strengths, protos);
-  const calibrated = calibrateFitScores(matches);
-  const shares = computeTypeProbabilities(calibrated, input.config.softmaxTemp || 1.0);
-  const { top3, gap, scoreGap } = rankTypes(shares, calibrated);
-  const conf = computeConfidence(scoreGap, gap, shares, input.config.confRawParams || { a:0.25, b:0.35, c:0.2 });
-  const profile = assembleProfileResult(input, strengths, calibrated, top3, gap, conf, fcSource);
-  return {
-    profile,
-    gap_to_second: profile.top_gap,
-    confidence_margin: profile.top_gap,
-    confidence_raw: Number(conf.raw.toFixed(4)),
-    confidence_calibrated: profile.conf_calibrated,
-    results_version: profile.results_version,
-    fc_source: fcSource,
-  };
-}
-
-export { runScoreEngine as scoreAssessment };
-

--- a/supabase/functions/get-results-by-session/index.ts
+++ b/supabase/functions/get-results-by-session/index.ts
@@ -10,23 +10,51 @@ serve(async (req) => {
   if (req.method === "OPTIONS") return new Response(null, { headers: corsHeaders });
   try {
     const { session_id, share_token } = await req.json();
-    if (!session_id) return new Response(JSON.stringify({ status: "error", error: "session_id required" }), { status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" } });
+    if (!session_id) {
+      return new Response(JSON.stringify({ status: "error", error: "session_id required" }), {
+        status: 400,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+    if (!share_token) {
+      console.log(`evt:tokenless_access,session_id:${session_id}`);
+      return new Response(JSON.stringify({ status: "error", error: "share token required" }), {
+        status: 401,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
     const url = Deno.env.get("SUPABASE_URL")!;
     const key = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
     const supabase = createClient(url, key);
 
-    const { data, error } = await supabase.rpc("get_results_by_session", { session_id, t: share_token ?? null });
+    const { data, error } = await supabase.rpc("get_profile_by_session", {
+      session_uuid: session_id,
+      token_text: share_token,
+    });
     if (error) {
-      return new Response(JSON.stringify({ status: "error", error: error.message }), { status: Number(error.code) || 401, headers: { ...corsHeaders, "Content-Type": "application/json" } });
+      return new Response(JSON.stringify({ status: "error", error: error.message }), {
+        status: Number(error.code) || 401,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
     }
     if (!data?.profile) {
-      return new Response(JSON.stringify({ status: "error", error: "not found" }), { status: 404, headers: { ...corsHeaders, "Content-Type": "application/json" } });
+      return new Response(JSON.stringify({ status: "error", error: "not found" }), {
+        status: 404,
+        headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
     }
     const profile = data.profile;
-    delete profile.share_token;
-    return new Response(JSON.stringify({ status: "success", profile, session: data.session }), { headers: { ...corsHeaders, "Content-Type": "application/json" } });
+    delete (profile as any).share_token;
+    return new Response(
+      JSON.stringify({ status: "success", profile, session: data.session }),
+      { headers: { ...corsHeaders, "Content-Type": "application/json" } },
+    );
   } catch (e: any) {
-    return new Response(JSON.stringify({ status: "error", error: e.message }), { status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" } });
+    return new Response(JSON.stringify({ status: "error", error: e.message }), {
+      status: 500,
+      headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
   }
 });
 

--- a/supabase/functions/score_fc_session/index.ts
+++ b/supabase/functions/score_fc_session/index.ts
@@ -12,7 +12,7 @@ serve(async (req) => {
   if (req.method === "OPTIONS") return new Response(null, { headers: cors });
 
   try {
-    const { session_id, basis = "functions", version = "v1.1" } = await req.json();
+    const { session_id, basis = "functions", version = "v1.2" } = await req.json();
     if (!session_id) {
       return new Response(JSON.stringify({ error: "session_id required" }), {
         status: 400, headers: { ...cors, "Content-Type": "application/json" },

--- a/supabase/migrations/20250915123001_unified_scoring_v121.sql
+++ b/supabase/migrations/20250915123001_unified_scoring_v121.sql
@@ -1,0 +1,29 @@
+-- up
+alter table assessment_sessions
+  alter column share_token set default gen_random_uuid();
+
+update scoring_config set value='v1.2.1' where key='results_version';
+
+alter table profiles enable row level security;
+revoke select on profiles from public;
+revoke select on profiles from anon;
+revoke select on profiles from authenticated;
+grant select on profiles to authenticated;
+create policy "profiles_select_own" on profiles for select
+  using (auth.uid() = user_id);
+
+grant execute on function get_profile_by_session(uuid,text) to anon, authenticated;
+
+-- down
+alter table assessment_sessions
+  alter column share_token drop default;
+
+update scoring_config set value='v1.2' where key='results_version';
+
+drop policy if exists "profiles_select_own" on profiles;
+revoke select on profiles from authenticated;
+grant select on profiles to anon;
+grant select on profiles to authenticated;
+alter table profiles disable row level security;
+
+revoke execute on function get_profile_by_session(uuid,text) from anon, authenticated;


### PR DESCRIPTION
## Summary
- add deterministic `scoreAssessment` engine module and regenerate fixtures
- refactor scoring edge functions to use shared engine and tokenized session flow
- harden profile access with RLS and token-aware results endpoint

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c7175d3020832aacdfb915fd87cd3a