### PR TITLE
Fix assessment save fallback and function routing

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,130 @@
   <head>
     <!-- Disable Attribution Reporting API to avoid third-party attestation errors (e.g., Facebook Pixel) -->
     <meta http-equiv="Permissions-Policy" content="attribution-reporting=()" />
+    <script>
+      (function configureSupabase() {
+        const existing = window.__APP_CONFIG__ || {};
+        const defaultConfig = {
+          SUPABASE_URL: "https://gnkuikentdtnatazeriu.supabase.co",
+          SUPABASE_ANON_KEY: "sb_publishable_Yu_Gv0Xfve27udk78CyT3w_qrbMR3Cn",
+        };
+        const config = Object.assign({}, defaultConfig, existing);
+
+        const normaliseUrl = (value) =>
+          typeof value === 'string' ? value.replace(/\/+$/, '') : undefined;
+
+        const supabaseUrl = normaliseUrl(config.SUPABASE_URL);
+        const configuredFunctionsUrl = normaliseUrl(config.SUPABASE_FUNCTION_URL);
+        const functionsUrl = configuredFunctionsUrl
+          || (supabaseUrl && supabaseUrl.includes('.supabase.co')
+            ? supabaseUrl.replace('.supabase.co', '.functions.supabase.co')
+            : undefined);
+
+        if (functionsUrl) {
+          config.SUPABASE_FUNCTION_URL = functionsUrl;
+        }
+
+        window.__APP_CONFIG__ = config;
+
+        const anonKey = config.SUPABASE_ANON_KEY;
+
+        function normaliseFunctionPath(path) {
+          const trimmed = path.replace(/^\/+/, '');
+          return trimmed.startsWith('functions/v1/')
+            ? trimmed.slice('functions/v1/'.length)
+            : trimmed;
+        }
+
+        window.__supabaseFunctionFetch = function(path, init) {
+          if (!functionsUrl) {
+            return Promise.reject(new Error('Supabase functions URL is not configured'));
+          }
+
+          const target = typeof path === 'string' && /^https?:/i.test(path)
+            ? path
+            : `${functionsUrl}/${normaliseFunctionPath(typeof path === 'string' ? path : '')}`;
+
+          const requestInit = Object.assign({}, init);
+          const headerBag = new Headers(requestInit.headers || {});
+
+          if (anonKey) {
+            if (!headerBag.has('apikey')) headerBag.set('apikey', anonKey);
+            if (!headerBag.has('Authorization')) headerBag.set('Authorization', `Bearer ${anonKey}`);
+          }
+
+          requestInit.headers = headerBag;
+          return fetch(target, requestInit);
+        };
+      })();
+    </script>
+    <script>
+      (function guardRudderIdentify() {
+        const REQUIRED_INTERVAL_MS = 500;
+
+        function toStringOrEmpty(value) {
+          return typeof value === 'string' ? value.trim() : '';
+        }
+
+        function hasRequiredTraits(traits) {
+          if (!traits || typeof traits !== 'object') return false;
+          const email = toStringOrEmpty(
+            traits.email || traits.Email || traits.userEmail || traits.user_email,
+          );
+          const phone = toStringOrEmpty(
+            traits.phone || traits.phone_number || traits.phoneNumber || traits.Phone,
+          );
+          const firstName = toStringOrEmpty(traits.firstName || traits.first_name || traits.FirstName);
+          const lastName = toStringOrEmpty(traits.lastName || traits.last_name || traits.LastName);
+          const postalCode = toStringOrEmpty(traits.postalCode || traits.postal_code || traits.zip);
+          const country = toStringOrEmpty(traits.country || traits.Country);
+          return Boolean(email && phone && (firstName || lastName || postalCode || country));
+        }
+
+        function wrapIdentify() {
+          const ra = window.rudderanalytics;
+          if (!ra || typeof ra.identify !== 'function' || ra.identify.__patched) {
+            return false;
+          }
+
+          const original = ra.identify.bind(ra);
+          ra.identify = function patchedIdentify() {
+            const args = Array.from(arguments);
+            const traitsCandidate = args.length > 1
+              ? args[1]
+              : (typeof args[0] === 'object' && args[0] !== null ? args[0] : undefined);
+
+            if (!hasRequiredTraits(traitsCandidate)) {
+              console.warn('rudderanalytics.identify skipped: missing required traits', traitsCandidate);
+              return Promise.resolve(null);
+            }
+
+            try {
+              const result = original.apply(this, args);
+              if (result && typeof result.then === 'function') {
+                return result.catch((err) => {
+                  console.warn('rudderanalytics.identify suppressed error', err);
+                  return null;
+                });
+              }
+              return result;
+            } catch (err) {
+              console.warn('rudderanalytics.identify suppressed error', err);
+              return Promise.resolve(null);
+            }
+          };
+          ra.identify.__patched = true;
+          return true;
+        }
+
+        if (!wrapIdentify()) {
+          const timer = setInterval(() => {
+            if (wrapIdentify()) {
+              clearInterval(timer);
+            }
+          }, REQUIRED_INTERVAL_MS);
+        }
+      })();
+    </script>
     <!-- Google Tag Manager -->
     <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
     new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
@@ -226,18 +350,24 @@
             props.email = window.redditNormalizeEmail(props.email);
           }
           if (window.rdt) rdt('track', eventName, props);
+          const requestInit = {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+              event_name: eventName,
+              conversion_id: props.conversion_id,
+              click_id: props.click_id,
+              email: props.email,
+            }),
+            keepalive: true,
+          };
           try {
-            fetch('/functions/v1/reddit-capi', {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({
-                event_name: eventName,
-                conversion_id: props.conversion_id,
-                click_id: props.click_id,
-                email: props.email,
-              }),
-              keepalive: true,
-            }).catch(() => {});
+            const invoke = window.__supabaseFunctionFetch;
+            if (typeof invoke === 'function') {
+              invoke('reddit-capi', requestInit).catch(() => {});
+            } else {
+              fetch('/functions/v1/reddit-capi', requestInit).catch(() => {});
+            }
           } catch (e) {
             // no-op
           }
@@ -340,12 +470,6 @@
     </noscript>
     
     <div id="root"></div>
-    <script id="app-config">
-      window.__APP_CONFIG__ = {
-        SUPABASE_URL: "https://gnkuikentdtnatazeriu.supabase.co",
-        SUPABASE_ANON_KEY: "sb_publishable_Yu_Gv0Xfve27udk78CyT3w_qrbMR3Cn"
-      };
-    </script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "ESLINT_USE_FLAT_CONFIG=false eslint .",
-    "test": "c8 tsx --test tests/fetchResults.test.ts tests/results.integration.test.ts tests/linkSessionsToUser.test.ts tests/linkSessionToAccount.test.ts tests/assessmentApi.test.ts tests/dashboardUtils.test.ts tests/recompute.invoke.test.ts tests/resultsLink.test.ts tests/backfillProfiles.test.ts tests/systemStatus.test.ts tests/individualsPage.test.tsx tests/organizationsPage.test.tsx tests/serviceCard.test.tsx tests/tiktokCapi.test.ts tests/tiktokClient.test.ts tests/getUserJwt.test.ts tests/classifyRpcError.test.ts supabase/functions/_shared/score-engine/__tests__/score-engine.test.ts tests/resultsLink.security.test.ts tests/finalizeAssessment.flow.test.ts",
+    "test": "c8 tsx --test tests/fetchResults.test.ts tests/results.integration.test.ts tests/linkSessionsToUser.test.ts tests/linkSessionToAccount.test.ts tests/assessmentApi.test.ts tests/dashboardUtils.test.ts tests/recompute.invoke.test.ts tests/resultsLink.test.ts tests/backfillProfiles.test.ts tests/systemStatus.test.ts tests/individualsPage.test.tsx tests/organizationsPage.test.tsx tests/serviceCard.test.tsx tests/tiktokCapi.test.ts tests/tiktokClient.test.ts tests/getUserJwt.test.ts tests/classifyRpcError.test.ts tests/saveResponseIdempotent.test.ts supabase/functions/_shared/score-engine/__tests__/score-engine.test.ts tests/resultsLink.security.test.ts tests/finalizeAssessment.flow.test.ts",
     "test:ci": "npm test",
     "preview": "vite preview",
     "typecheck": "tsc -p tsconfig.json --noEmit || echo \"typecheck skipped: no tsconfig.json\"",

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -3,6 +3,7 @@ import { createClient as createSupabaseClient } from "@supabase/supabase-js";
 type AppConfig = {
   SUPABASE_URL?: string;
   SUPABASE_ANON_KEY?: string;
+  SUPABASE_FUNCTION_URL?: string;
 };
 
 declare global {

--- a/src/services/assessmentSaves.ts
+++ b/src/services/assessmentSaves.ts
@@ -1,3 +1,4 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
 import { supabase } from "@/lib/supabase/client";
 
 interface SaveResponseParams {
@@ -10,6 +11,52 @@ interface SaveResponseParams {
   responseTime?: number;
 }
 
+type SupabaseRpcClient = Pick<
+  SupabaseClient<any, any, any>,
+  "rpc" | "functions"
+>;
+
+type RpcPayload = {
+  p_session_id: string;
+  p_question_id: number;
+  p_answer: Record<string, unknown>;
+  p_source: string;
+};
+
+type EdgePayload = {
+  session_id: string;
+  question_id: number;
+  question_text?: string;
+  question_type?: string;
+  question_section?: string;
+  response_time_ms?: number;
+  answer_value?: string;
+  answer_numeric?: number;
+  answer_array?: string[] | number[];
+  answer_object?: Record<string, unknown>;
+};
+
+export type SaveResponseErrorKind = "rpc_error" | "edge_error";
+
+export class SaveResponseException extends Error {
+  readonly kind: SaveResponseErrorKind;
+  readonly cause: unknown;
+
+  constructor(kind: SaveResponseErrorKind, cause: unknown, message?: string) {
+    super(
+      message ??
+        (cause instanceof Error
+          ? cause.message
+          : typeof cause === "string"
+            ? cause
+            : "Unknown response save failure")
+    );
+    this.name = "SaveResponseException";
+    this.kind = kind;
+    this.cause = cause;
+  }
+}
+
 // Track in-flight saves to prevent duplicates
 const inflightSaves = new Map<string, Promise<void>>();
 
@@ -17,15 +64,14 @@ const inflightSaves = new Map<string, Promise<void>>();
  * Idempotent response save using upsert to prevent 409 conflicts
  * Uses proper in-flight tracking and controlled state management
  */
-export async function saveResponseIdempotent(params: SaveResponseParams): Promise<void> {
+export async function saveResponseIdempotent(
+  params: SaveResponseParams,
+  client: SupabaseRpcClient = supabase
+): Promise<void> {
   const {
     sessionId,
     questionId,
-    answer,
-    questionText,
-    questionType,
-    questionSection,
-    responseTime
+    answer
   } = params;
 
   // Generate unique key for this save operation
@@ -38,7 +84,7 @@ export async function saveResponseIdempotent(params: SaveResponseParams): Promis
   }
 
   // Create the save promise
-  const savePromise = performIdempotentSave(params);
+  const savePromise = performIdempotentSave(params, client);
   
   // Track the save
   inflightSaves.set(saveKey, savePromise);
@@ -54,15 +100,14 @@ export async function saveResponseIdempotent(params: SaveResponseParams): Promis
 /**
  * Perform the actual idempotent save operation
  */
-async function performIdempotentSave(params: SaveResponseParams): Promise<void> {
+async function performIdempotentSave(
+  params: SaveResponseParams,
+  client: SupabaseRpcClient
+): Promise<void> {
   const {
     sessionId,
     questionId,
-    answer,
-    questionText,
-    questionType,
-    questionSection,
-    responseTime
+    answer
   } = params;
 
   console.log('💾 Saving response (idempotent):', { 
@@ -72,58 +117,117 @@ async function performIdempotentSave(params: SaveResponseParams): Promise<void> 
       answer.substring(0, 50) + '...' : answer 
   });
 
-  // Prepare the response data (no updated_at to avoid PGRST204)
-  const responseData: any = {
-    session_id: sessionId,
-    question_id: questionId,
-    question_text: questionText,
-    question_type: questionType,
-    question_section: questionSection
+  const rpcPayload = buildRpcPayload(params);
+  const edgePayload = buildEdgePayload(params);
+
+  try {
+    const { error } = await client.rpc('save_assessment_response', rpcPayload);
+
+    if (!error) {
+      console.log('✅ Response saved successfully (upserted via RPC)');
+      return;
+    }
+
+    if (isRpcMissingError(error)) {
+      console.warn('⚠️ RPC save failed (missing function). Falling back to edge function.', error);
+      await invokeEdgeFallback(client, edgePayload);
+      console.log('✅ Response saved successfully via edge function fallback');
+      return;
+    }
+
+    console.error('💥 Response save failed with non-recoverable RPC error:', error);
+    throw new SaveResponseException('rpc_error', error);
+  } catch (rpcException) {
+    if (rpcException instanceof SaveResponseException) {
+      throw rpcException;
+    }
+    console.error('💥 Unexpected RPC invocation failure. Attempting edge fallback.', rpcException);
+    try {
+      await invokeEdgeFallback(client, edgePayload);
+      console.log('✅ Response saved successfully via edge function fallback');
+      return;
+    } catch (edgeError) {
+      throw new SaveResponseException('rpc_error', rpcException, 'RPC request failed before reaching PostgREST');
+    }
+  }
+}
+
+function buildRpcPayload(params: SaveResponseParams): RpcPayload {
+  const answerJson: Record<string, unknown> = {
+    question_text: params.questionText,
+    question_type: params.questionType,
+    question_section: params.questionSection,
   };
 
-  // Handle different answer types properly
-  if (Array.isArray(answer)) {
-    responseData.answer_array = answer;
-    responseData.answer_value = JSON.stringify(answer);
-  } else if (typeof answer === 'number') {
-    responseData.answer_numeric = answer;
-    responseData.answer_value = answer.toString();
-  } else {
-    responseData.answer_value = String(answer);
+  if (Array.isArray(params.answer)) {
+    answerJson.answer_array = params.answer;
+  } else if (typeof params.answer === 'number') {
+    answerJson.answer_numeric = params.answer;
+  } else if (params.answer != null) {
+    answerJson.answer_value = String(params.answer);
   }
 
-  if (responseTime !== undefined) {
-    responseData.response_time_ms = responseTime;
-  }
-
-  // Call RPC to bypass RLS via SECURITY DEFINER function
-  const answerJson: any = {
-    question_text: questionText,
-    question_type: questionType,
-    question_section: questionSection,
-  };
-
-  if (Array.isArray(answer)) {
-    answerJson.answer_array = answer;
-  } else if (typeof answer === 'number') {
-    answerJson.answer_numeric = answer;
-  } else if (answer != null) {
-    answerJson.answer_value = String(answer);
-  }
-
-  const { data, error } = await supabase.rpc('save_assessment_response', {
-    p_session_id: sessionId,
-    p_question_id: Number(questionId),
+  return {
+    p_session_id: params.sessionId,
+    p_question_id: Number(params.questionId),
     p_answer: answerJson,
-    p_source: 'web'
+    p_source: 'web',
+  };
+}
+
+function buildEdgePayload(params: SaveResponseParams): EdgePayload {
+  const payload: EdgePayload = {
+    session_id: params.sessionId,
+    question_id: Number(params.questionId),
+    question_text: params.questionText,
+    question_type: params.questionType,
+    question_section: params.questionSection,
+  };
+
+  if (params.responseTime !== undefined) {
+    payload.response_time_ms = params.responseTime;
+  }
+
+  if (Array.isArray(params.answer)) {
+    payload.answer_array = params.answer;
+  } else if (typeof params.answer === 'number') {
+    payload.answer_numeric = params.answer;
+    payload.answer_value = params.answer.toString();
+  } else if (params.answer != null) {
+    payload.answer_value = String(params.answer);
+  }
+
+  return payload;
+}
+
+function isRpcMissingError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') {
+    return false;
+  }
+
+  const code = 'code' in error ? String((error as { code?: unknown }).code ?? '') : '';
+  if (code === '404' || code === 'PGRST404') {
+    return true;
+  }
+
+  const message = 'message' in error ? String((error as { message?: unknown }).message ?? '') : '';
+  return message.toLowerCase().includes('not found') || message.toLowerCase().includes('does not exist');
+}
+
+async function invokeEdgeFallback(client: SupabaseRpcClient, payload: EdgePayload): Promise<void> {
+  const { data, error } = await client.functions.invoke('save_response', {
+    body: payload,
   });
 
   if (error) {
-    console.error('💥 Response save failed:', error);
-    throw error;
+    console.error('💥 Edge function save_response failed:', error);
+    throw new SaveResponseException('edge_error', error);
   }
 
-  console.log('✅ Response saved successfully (upserted)');
+  if (data && typeof data === 'object' && 'error' in data && (data as { error?: unknown }).error) {
+    console.error('💥 Edge function save_response returned error payload:', data);
+    throw new SaveResponseException('edge_error', (data as { error?: unknown }).error);
+  }
 }
 
 /**

--- a/tests/saveResponseIdempotent.test.ts
+++ b/tests/saveResponseIdempotent.test.ts
@@ -1,0 +1,139 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+(globalThis as any).window = {
+  __APP_CONFIG__: {
+    SUPABASE_URL: 'https://example.supabase.co',
+    SUPABASE_ANON_KEY: 'anon',
+  },
+};
+
+const { saveResponseIdempotent, SaveResponseException } = await import('../src/services/assessmentSaves');
+
+type MockRpcResult = { data: unknown; error: any } | Promise<{ data: unknown; error: any }>;
+
+type MockClient = {
+  rpc: (name: string, payload: Record<string, unknown>) => MockRpcResult;
+  functions: {
+    invoke: (name: string, options: { body: Record<string, unknown> }) => MockRpcResult;
+  };
+};
+
+type PartialParams = Partial<Parameters<typeof saveResponseIdempotent>[0]>;
+
+function createParams(overrides: PartialParams = {}) {
+  return Object.assign(
+    {
+      sessionId: 'session-1',
+      questionId: 42,
+      answer: 'Yes',
+      questionText: 'Example?',
+      questionType: 'single',
+      questionSection: 'intro',
+    },
+    overrides,
+  );
+}
+
+function createClient(impl: Partial<MockClient>): MockClient {
+  return {
+    rpc: impl.rpc || (async () => ({ data: null, error: null })),
+    functions: {
+      invoke: impl.functions?.invoke || (async () => ({ data: { ok: true }, error: null })),
+    },
+  };
+}
+
+test('persists responses via RPC when function is available', async () => {
+  let rpcCalls = 0;
+  const client = createClient({
+    rpc: async (name, payload) => {
+      rpcCalls += 1;
+      assert.equal(name, 'save_assessment_response');
+      assert.equal(payload.p_session_id, 'session-1');
+      assert.equal(payload.p_question_id, 42);
+      return { data: null, error: null };
+    },
+    functions: {
+      invoke: async () => {
+        throw new Error('edge fallback should not execute when RPC succeeds');
+      },
+    },
+  });
+
+  await saveResponseIdempotent(createParams(), client as any);
+  assert.equal(rpcCalls, 1);
+});
+
+test('falls back to edge function when RPC is missing', async () => {
+  let fallbackCalls = 0;
+  let capturedBody: Record<string, unknown> | null = null;
+  const client = createClient({
+    rpc: async () => ({ data: null, error: { code: 'PGRST404', message: 'not found' } }),
+    functions: {
+      invoke: async (name, options) => {
+        fallbackCalls += 1;
+        assert.equal(name, 'save_response');
+        capturedBody = options.body;
+        return { data: { ok: true }, error: null };
+      },
+    },
+  });
+
+  await saveResponseIdempotent(
+    createParams({ answer: ['A', 'B'], questionId: '7' }),
+    client as any,
+  );
+
+  assert.equal(fallbackCalls, 1);
+  assert.ok(capturedBody);
+  assert.equal(capturedBody?.session_id, 'session-1');
+  assert.equal(capturedBody?.question_id, 7);
+  assert.deepEqual(capturedBody?.answer_array, ['A', 'B']);
+});
+
+test('uses edge fallback when RPC call throws', async () => {
+  let fallbackCalls = 0;
+  const client = createClient({
+    rpc: async () => {
+      throw new Error('network timeout');
+    },
+    functions: {
+      invoke: async () => {
+        fallbackCalls += 1;
+        return { data: { ok: true }, error: null };
+      },
+    },
+  });
+
+  await saveResponseIdempotent(createParams({ questionId: 5 }), client as any);
+  assert.equal(fallbackCalls, 1);
+});
+
+test('throws typed error when RPC returns non-recoverable error', async () => {
+  const client = createClient({
+    rpc: async () => ({ data: null, error: { code: '400', message: 'invalid payload' } }),
+  });
+
+  await assert.rejects(
+    () => saveResponseIdempotent(createParams(), client as any),
+    (error: unknown) =>
+      error instanceof SaveResponseException &&
+      error.kind === 'rpc_error' &&
+      /invalid payload/i.test(String((error.cause as { message?: string } | undefined)?.message ?? '')),
+  );
+});
+
+test('propagates edge error when fallback fails', async () => {
+  const client = createClient({
+    rpc: async () => ({ data: null, error: { code: 'PGRST404', message: 'missing' } }),
+    functions: {
+      invoke: async () => ({ data: null, error: { message: 'denied' } }),
+    },
+  });
+
+  await assert.rejects(
+    () => saveResponseIdempotent(createParams(), client as any),
+    (error: unknown) => error instanceof SaveResponseException && error.kind === 'edge_error',
+  );
+});

--- a/tracking/cal-tracking.js
+++ b/tracking/cal-tracking.js
@@ -95,11 +95,17 @@ async function postTikTokEvent(body) {
     return;
   }
   try {
-    await fetch('/functions/v1/tiktok-capi', {
+    const request = {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body),
-    });
+    };
+    const invoke = window.__supabaseFunctionFetch;
+    if (typeof invoke === 'function') {
+      await invoke('tiktok-capi', request);
+    } else {
+      await fetch('/functions/v1/tiktok-capi', request);
+    }
   } catch {
     /* swallow */
   }


### PR DESCRIPTION
## Summary
- add a shared Supabase function fetch helper, guard RudderStack identify, and stop relying on relative function URLs in marketing scripts
- make assessment response saves resilient by falling back to the edge function when the RPC is missing and return typed errors
- update tracking utilities to reuse the new helper and add focused tests for the idempotent save flow

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c85d4463e4832aac44e14d0d6b7996