### PR TITLE
Align results RPC calls with unified scoring signature

### DIFF
--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -3124,7 +3124,7 @@ export type Database = {
         Returns: Json[]
       }
       get_results_by_session: {
-        Args: { session_id: string; t?: string }
+        Args: { p_session_id: string; t?: string }
         Returns: Json
       }
       get_user_assessment_scores: {

--- a/src/pages/Results.tsx
+++ b/src/pages/Results.tsx
@@ -157,9 +157,14 @@ export default function Results() {
     (async () => {
       try {
         // Single, authoritative RPC. Token path (t set) or owner path (t null).
+        const rpcArgs =
+          shareToken === null
+            ? { p_session_id: sessionId }
+            : { p_session_id: sessionId, t: shareToken };
+
         const { data: res, error } = await supabase.rpc(
           "get_results_by_session",
-          { session_id: sessionId, t: shareToken }
+          rpcArgs
         );
 
         if (error) throw error;

--- a/tests/resultsLink.security.test.ts
+++ b/tests/resultsLink.security.test.ts
@@ -2,6 +2,8 @@ import { createClient } from "@supabase/supabase-js";
 import test from "node:test";
 import assert from "node:assert/strict";
 
+import type { Database } from "../src/integrations/supabase/types";
+
 const url = process.env.SUPABASE_URL;
 const anon = process.env.SUPABASE_ANON_KEY;
 const service = process.env.SUPABASE_SERVICE_ROLE_KEY;
@@ -9,35 +11,81 @@ const service = process.env.SUPABASE_SERVICE_ROLE_KEY;
 if (!url || !anon || !service) {
   test.skip("requires Supabase env", () => {});
 } else {
-  test("token access succeeds and respects ttl", async () => {
-    const svc = createClient(url, service);
-  const { data: sess } = await svc.from("assessment_sessions").insert({}).select().single();
-  const { data: prof } = await svc
-    .from("profiles")
-    .insert({
-      session_id: sess.id,
-      user_id: "00000000-0000-0000-0000-000000000000",
-      share_token: "tok",
-      share_token_expires_at: new Date(Date.now() + 1000).toISOString(),
-    })
-    .select()
-    .single();
+  test(
+    "token access succeeds, rejects legacy arg, and respects ttl",
+    async () => {
+      const svc = createClient<Database>(url, service, {
+        auth: { persistSession: false },
+      });
+      const futureExpiry = new Date(Date.now() + 60_000).toISOString();
 
-  const anonClient = createClient(url, anon);
-  const { data } = await anonClient.rpc("get_results_by_session", {
-    session_id: sess.id,
-    t: "tok",
-  });
-  assert.equal(data.profile.id, prof.id);
+      const { data: sess, error: sessionError } = await svc
+        .from("assessment_sessions")
+        .insert({
+          share_token: "tok-session",
+          share_token_expires_at: futureExpiry,
+        })
+        .select()
+        .single();
+      assert.equal(sessionError, null);
+      assert.ok(sess);
+      if (!sess) throw new Error("failed to create session");
 
-  await svc
-    .from("assessment_sessions")
-    .update({ share_token_expires_at: new Date(Date.now() - 1000).toISOString() })
-    .eq("id", sess.id);
-  const { data: expired } = await anonClient.rpc("get_results_by_session", {
-    session_id: sess.id,
-    t: "tok",
-  });
-  assert.equal(expired, null);
-  });
+      const { data: prof, error: profileError } = await svc
+        .from("profiles")
+        .insert({
+          session_id: sess.id,
+          user_id: "00000000-0000-0000-0000-000000000000",
+          share_token: "tok",
+        })
+        .select()
+        .single();
+      assert.equal(profileError, null);
+      assert.ok(prof);
+      if (!prof) throw new Error("failed to create profile");
+
+      const anonClient = createClient<Database>(url, anon, {
+        auth: { persistSession: false },
+      });
+
+      const { data, error } = await anonClient.rpc("get_results_by_session", {
+        p_session_id: sess.id,
+        t: "tok",
+      });
+      assert.equal(error, null);
+      assert.ok(data);
+      if (!data) throw new Error("missing results payload");
+      const profile = (data as any).profile;
+      assert.ok(profile);
+      assert.equal(profile.id, prof.id);
+
+      const { error: expireError } = await svc
+        .from("assessment_sessions")
+        .update({
+          share_token_expires_at: new Date(Date.now() - 60_000).toISOString(),
+        })
+        .eq("id", sess.id);
+      assert.equal(expireError, null);
+
+      const { data: expired, error: expiredError } = await anonClient.rpc(
+        "get_results_by_session",
+        {
+          p_session_id: sess.id,
+          t: "tok",
+        }
+      );
+      assert.equal(expiredError, null);
+      assert.equal(expired, null);
+
+      // @ts-expect-error - session_id parameter was removed in unified scoring migration
+      const legacyCall = await anonClient.rpc("get_results_by_session", {
+        session_id: sess.id,
+        t: "tok",
+      });
+      assert.ok(
+        legacyCall.error,
+        "Expected RPC to reject legacy parameter name"
+      );
+    }
+  );
 }


### PR DESCRIPTION
## Summary
- update the results page to call `get_results_by_session` with the new `p_session_id` argument
- regenerate the Supabase client types so the RPC contract now expects `{ p_session_id, t? }`
- harden the results link security test to cover the renamed parameter, TTL handling, and reject the legacy contract

## Testing
- npm run typecheck
- npm run lint
- npx tsx --test tests/resultsLink.security.test.ts


------
https://chatgpt.com/codex/tasks/task_e_68c99c4f43c0832a9b924b11aca9bd9b