### PR TITLE
Restore finalize cron 248 threshold and version guard

### DIFF
--- a/docs/auto-finalize-248-setup.md
+++ b/docs/auto-finalize-248-setup.md
@@ -18,6 +18,7 @@ This system automatically finalizes sessions with 248+ completed questions and p
 - **Purpose**: Auto-finalize 248+ question sessions with email addresses
 - **Logic**: 
   - Only recomputes if responses_hash changed or profile missing
+  - Recomputes when stored results_version mismatches the current release
   - Calls `finalizeAssessment` edge function for scoring
   - Updates `responses_hash` after finalization
   - Ensures share tokens exist for all sessions


### PR DESCRIPTION
## Summary
- require the cron-force-finalize edge function to only process sessions with at least 248 answers and force recompute when results_version is stale
- document the restored 248-question trigger and the version-mismatch recompute behavior

## Testing
- npm run verify:functions

------
https://chatgpt.com/codex/tasks/task_e_68cb497246f0832aa113b9dc644d621b