### PR TITLE
Results stabilization: single results fetch w/ JWT or token, one-shot linking, remove restricted REST reads, and solid v1 fallback

### DIFF
--- a/execute_evidence_gate.ts
+++ b/execute_evidence_gate.ts
@@ -1,4 +1,5 @@
 import { createClient } from '@supabase/supabase-js';
+import * as fs from 'fs';
 
 const url = "https://gnkuikentdtnatazeriu.supabase.co";
 const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
@@ -46,7 +47,7 @@ async function executeEvidenceGate() {
   }
   
   const fcValid = fcScores?.[0]?.version === 'v1.2' && fcScores?.[0]?.scores_json;
-  console.log(`FC Scores: version=${fcScores?.[0]?.version}, has_scores=${!!fcScores?.[0]?.scores_json} ${fcValid ? '✅' : '❌'}`);
+  console.log(`FC Scores: version=${fcScores?.[0]?.version}, has_scores=${Boolean(fcScores?.[0]?.scores_json)} ${fcValid ? '✅' : '❌'}`);
   
   // Step 3: Verify profiles exists with correct version
   console.log('\n🔍 Step 3: Verifying profiles...');
@@ -127,7 +128,7 @@ async function executeEvidenceGate() {
 
 ### FC Scores
 - **Version**: ${fcScores?.[0]?.version}
-- **Scores Present**: ${!!fcScores?.[0]?.scores_json ? 'Yes' : 'No'}
+- **Scores Present**: ${fcScores?.[0]?.scores_json ? 'Yes' : 'No'}
 - **Blocks Answered**: ${fcScores?.[0]?.blocks_answered || 0}
 - **Status**: ${fcValid ? '✅ PASS' : '❌ FAIL'}
 
@@ -151,7 +152,6 @@ async function executeEvidenceGate() {
 ${overallPass ? 'Hard evidence captured: fc_scores v1.2 + profiles v1.2.1 + tokenized security enforced. Ready for backfill phase.' : 'Evidence validation failed. Do not proceed to backfill until issues are resolved.'}
 `;
 
-  const fs = require('fs');
   fs.writeFileSync('evidence_gate.md', evidenceReport);
   
   console.log('\n📄 Evidence report written to evidence_gate.md');

--- a/src/hooks/useEmailSessionManager.ts
+++ b/src/hooks/useEmailSessionManager.ts
@@ -2,7 +2,7 @@ import { useState, useCallback } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { useToast } from '@/hooks/use-toast';
 import { trackLead } from '@/lib/analytics';
-import { linkSessionToAccount as linkSessionToAccountService } from '@/services/sessionLinking';
+import { ensureSessionLinked } from '@/services/sessionLinking';
 
 export interface SessionData {
   session_id: string;
@@ -109,16 +109,14 @@ export function useEmailSessionManager() {
     try {
       console.log('Linking session to account:', { sessionId, userId, email });
 
-      const res = await linkSessionToAccountService(
-        supabase,
+      const linked = await ensureSessionLinked({
         sessionId,
         userId,
-        email
-      );
+        email,
+      });
 
-      if (!res.ok) {
-        const err = 'error' in res ? (res as any).error : undefined;
-        console.error('Error linking session to account:', err);
+      if (!linked) {
+        console.error('Error linking session to account');
         toast({
           title: "Link Error",
           description: "Failed to link session to your account.",

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -123,10 +123,14 @@ export const trackResultsViewed = (sessionId: string, typeCode?: string) => {
       type_code: typeCode
     });
   }
-  
+
   // Fire custom event for Reddit S2S tracking
-  if (typeof window !== 'undefined') {
-    window.dispatchEvent(new CustomEvent('app:results:viewed', { 
+  if (
+    typeof window !== 'undefined' &&
+    typeof window.dispatchEvent === 'function' &&
+    typeof window.CustomEvent === 'function'
+  ) {
+    window.dispatchEvent(new window.CustomEvent('app:results:viewed', {
       detail: { sessionId, typeCode }
     }));
   }

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -3,12 +3,34 @@ import { createClient } from '@supabase/supabase-js';
 const SUPABASE_URL = "https://gnkuikentdtnatazeriu.supabase.co";
 const SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imdua3Vpa2VudGR0bmF0YXplcml1Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTM3MzI2MDQsImV4cCI6MjA2OTMwODYwNH0.wCk8ngoDqGW4bMIAjH5EttXsoBwdk4xnIViJZCezs-U";
 
+const getStorage = (): Storage => {
+  if (typeof window !== 'undefined' && window.localStorage) {
+    return window.localStorage;
+  }
+
+  const memoryStore = new Map<string, string>();
+  return {
+    get length() {
+      return memoryStore.size;
+    },
+    clear: () => memoryStore.clear(),
+    getItem: (key: string) => (memoryStore.has(key) ? memoryStore.get(key)! : null),
+    key: (index: number) => Array.from(memoryStore.keys())[index] ?? null,
+    removeItem: (key: string) => {
+      memoryStore.delete(key);
+    },
+    setItem: (key: string, value: string) => {
+      memoryStore.set(key, value);
+    },
+  } satisfies Storage;
+};
+
 // Create singleton client to avoid Multiple GoTrueClient instances
 const existing = (globalThis as any).__prism_supabase as ReturnType<typeof createClient> | undefined;
 
 export const supabase = existing ?? createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
   auth: {
-    storage: localStorage,
+    storage: getStorage(),
     persistSession: true,
     autoRefreshToken: true,
     storageKey: 'prism-auth'

--- a/src/services/resultsApi.ts
+++ b/src/services/resultsApi.ts
@@ -1,0 +1,64 @@
+import { supabase } from "@/lib/supabaseClient";
+
+let cachedFunctionsBase: string | null = null;
+
+function resolveFunctionsBase(): string {
+  if (cachedFunctionsBase) return cachedFunctionsBase;
+
+  const envUrl =
+    process.env.NEXT_PUBLIC_SUPABASE_FUNCTIONS_URL ??
+    (typeof import.meta !== "undefined" && (import.meta as any).env?.VITE_SUPABASE_URL
+      ? `${(import.meta as any).env.VITE_SUPABASE_URL}/functions/v1`
+      : undefined);
+
+  const resolved = envUrl ?? 'https://gnkuikentdtnatazeriu.supabase.co/functions/v1';
+
+  cachedFunctionsBase = resolved;
+  return cachedFunctionsBase;
+}
+
+export type ResultsFetchPayload = Record<string, any>;
+
+export async function fetchResultsBySession(
+  sessionId: string,
+  shareToken?: string | null
+): Promise<ResultsFetchPayload> {
+  if (!sessionId) {
+    throw new Error("sessionId is required");
+  }
+
+  const url = `${resolveFunctionsBase()}/get-results-by-session`;
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+
+  const body: Record<string, unknown> = { session_id: sessionId };
+
+  if (shareToken) {
+    body.share_token = shareToken;
+  } else {
+    const { data } = await supabase.auth.getSession();
+    const jwt = data?.session?.access_token;
+    if (jwt) {
+      headers.Authorization = `Bearer ${jwt}`;
+    }
+  }
+
+  const response = await fetch(url, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+
+  const payload = await response.json().catch(() => ({}));
+
+  if (!response.ok || (payload && typeof payload === "object" && payload.ok === false)) {
+    const message =
+      (payload && typeof payload === "object" && "error" in payload && typeof payload.error === "string"
+        ? payload.error
+        : null) ?? `get-results-by-session ${response.status}`;
+    throw new Error(message);
+  }
+
+  return payload as ResultsFetchPayload;
+}

--- a/tests/linkSessionsToUser.test.ts
+++ b/tests/linkSessionsToUser.test.ts
@@ -1,76 +1,36 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { linkSessionsToUser } from '../src/services/sessionLinking';
+import { ensureSessionLinked } from '../src/services/sessionLinking';
 
-function createClient(opts: {
-  sessions?: Array<{ id: string }>;
-  selectError?: unknown;
-  updateError?: unknown;
-}) {
-  const state = { updateCalled: false, ids: [] as string[] };
-  const client: any = {
-    from() {
-      return {
-        select() {
-          return {
-            eq() {
-              return {
-                is() {
-                  if (opts.selectError) {
-                    return { data: null, error: opts.selectError };
-                  }
-                  return { data: opts.sessions ?? [], error: null };
-                },
-              };
-            },
-          };
-        },
-        update() {
-          return {
-            in(_: string, ids: string[]) {
-              state.updateCalled = true;
-              state.ids = ids;
-              if (opts.updateError) {
-                return { error: opts.updateError };
-              }
-              return { error: null };
-            },
-          };
-        },
-      };
-    },
-    _state: state,
-  };
-  return client;
-}
+const originalFetch = globalThis.fetch;
 
-test('links unowned sessions to user', async () => {
-  const client = createClient({ sessions: [{ id: 's1' }, { id: 's2' }] });
-  const res = await linkSessionsToUser(client as any, 'a@b.com', 'u1');
-  assert.deepEqual(res, { ok: true, linked: 2 });
-  assert.equal(client._state.updateCalled, true);
-  assert.deepEqual(client._state.ids, ['s1', 's2']);
+test('ensureSessionLinked short-circuits without session id', async () => {
+  globalThis.fetch = (async () => {
+    throw new Error('should not be called');
+  }) as typeof fetch;
+  const result = await ensureSessionLinked({ sessionId: '', userId: 'u1' });
+  assert.equal(result, false);
 });
 
-test('returns zero when no sessions found', async () => {
-  const client = createClient({ sessions: [] });
-  const res = await linkSessionsToUser(client as any, 'a@b.com', 'u1');
-  assert.deepEqual(res, { ok: true, linked: 0 });
-  assert.equal(client._state.updateCalled, false);
+test('ensureSessionLinked short-circuits without user id', async () => {
+  globalThis.fetch = (async () => {
+    throw new Error('should not be called');
+  }) as typeof fetch;
+  const result = await ensureSessionLinked({ sessionId: 's1', userId: '' });
+  assert.equal(result, false);
 });
 
-test('propagates select errors', async () => {
-  const err = new Error('fail');
-  const client = createClient({ selectError: err });
-  const res = await linkSessionsToUser(client as any, 'a@b.com', 'u1');
-  assert.equal(res.ok, false);
-  assert.equal((res as any).error, err);
+test('ensureSessionLinked handles null email gracefully', async () => {
+  let captured: any = null;
+  globalThis.fetch = (async (_input, init) => {
+    captured = init?.body ? JSON.parse(String(init.body)) : null;
+    return new Response('{}', { status: 200 });
+  }) as typeof fetch;
+  const result = await ensureSessionLinked({ sessionId: 's2', userId: 'u2' });
+  assert.equal(result, true);
+  assert.equal(captured.email, null);
 });
 
-test('propagates update errors', async () => {
-  const err = new Error('update');
-  const client = createClient({ sessions: [{ id: 's1' }], updateError: err });
-  const res = await linkSessionsToUser(client as any, 'a@b.com', 'u1');
-  assert.equal(res.ok, false);
-  assert.equal((res as any).error, err);
+test.after(() => {
+  globalThis.fetch = originalFetch;
 });


### PR DESCRIPTION
## Summary
- add a dedicated results API client that posts to get-results-by-session with owner JWT or share token and update the results route to use it
- rework session linking to call the link_session_to_account edge function once, drop direct REST updates, and adjust auth/email flows accordingly
- render v1 fallback data when v2 arrays are incomplete, clean up analytics events, and refresh unit/integration tests for the new flow

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68cc89c47ac4832a92440677ad253f43