### PR TITLE
Add session-based admin Supabase key configuration

### DIFF
--- a/tests/adminTools.test.ts
+++ b/tests/adminTools.test.ts
@@ -137,3 +137,24 @@ test("input validation rejects invalid limits", async () => {
   await assert.rejects(() => adminTools.backfillBrokenSessions({ days: -1, batchSize: 10 }), /positive number/);
   await assert.rejects(() => adminTools.backfillBrokenSessions({ days: 10, batchSize: 0 }), /positive number/);
 });
+
+test("service role key can be configured at runtime", async () => {
+  const original = process.env.VITE_SUPABASE_SERVICE_ROLE_KEY;
+  process.env.VITE_SUPABASE_SERVICE_ROLE_KEY = "";
+  adminTools.__testing.resetCaches();
+  adminTools.clearAdminServiceRoleKey();
+  assert.equal(adminTools.isAdminServiceRoleKeyConfigured(), false);
+
+  adminTools.configureAdminServiceRoleKey("temp-key");
+  assert.equal(adminTools.isAdminServiceRoleKeyConfigured(), true);
+
+  adminTools.clearAdminServiceRoleKey();
+  assert.equal(adminTools.isAdminServiceRoleKeyConfigured(), false);
+
+  process.env.VITE_SUPABASE_SERVICE_ROLE_KEY = original;
+  adminTools.__testing.resetCaches();
+});
+
+test("configuring with empty key is rejected", () => {
+  assert.throws(() => adminTools.configureAdminServiceRoleKey("  \t"), /cannot be empty/);
+});


### PR DESCRIPTION
## Summary
- allow admin tooling to read the Supabase service role key from env or session storage and expose runtime configuration helpers
- add controls in the full admin UI to configure and clear the service role key before running privileged actions
- cover the new configuration paths and validation with unit tests

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ccc0f411f0832a860a9d7c3336d56c