### PR TITLE
Improve results data freshness with React Query

### DIFF
--- a/src/features/results/queryKeys.ts
+++ b/src/features/results/queryKeys.ts
@@ -1,0 +1,10 @@
+const baseKey = ['results'] as const;
+
+export const resultsQueryKeys = {
+  all: baseKey,
+  sessionScope: (sessionId: string) => [...baseKey, sessionId] as const,
+  session: (sessionId: string, shareToken?: string | null) =>
+    [...resultsQueryKeys.sessionScope(sessionId), shareToken ?? null] as const,
+} as const;
+
+export type ResultsQueryKey = ReturnType<typeof resultsQueryKeys.session>;

--- a/src/pages/Assessment.tsx
+++ b/src/pages/Assessment.tsx
@@ -7,10 +7,13 @@ import { AssessmentIntro } from '@/components/assessment/AssessmentIntro';
 import { supabase } from '@/integrations/supabase/client';
 import { trackAssessmentComplete, trackLead } from '@/lib/analytics';
 import { TOTAL_PRISM_QUESTIONS } from '@/services/prismConfig';
+import { useQueryClient } from '@tanstack/react-query';
+import { resultsQueryKeys } from '@/features/results/queryKeys';
 
 const Assessment = () => {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
 
   const resume = searchParams.get('resume');
   const start = searchParams.get('start');
@@ -33,6 +36,7 @@ const Assessment = () => {
       if (error) throw error;
       trackAssessmentComplete(sessionId, responses.length);
       trackLead(undefined, { source: 'assessment_complete' });
+      queryClient.removeQueries({ queryKey: resultsQueryKeys.sessionScope(sessionId) });
       const token = (data as any)?.share_token;
       navigate(
         `/results/${sessionId}${token ? `?t=${token}` : ''}`,

--- a/src/services/resultsApi.ts
+++ b/src/services/resultsApi.ts
@@ -1,6 +1,16 @@
 import supabase from "@/lib/supabaseClient";
 import { IS_PREVIEW } from "@/lib/env";
 
+export class ResultsApiError extends Error {
+  status?: number;
+
+  constructor(message: string, status?: number) {
+    super(message);
+    this.name = "ResultsApiError";
+    this.status = status;
+  }
+}
+
 let cachedFunctionsBase: string | null = null;
 
 function resolveFunctionsBase(): string {
@@ -88,7 +98,7 @@ export async function fetchResultsBySession(
         typeof payload.error === "string" && payload.error.length > 0
           ? payload.error
           : `get-results-by-session ${response.status}`;
-      throw new Error(message);
+      throw new ResultsApiError(message, response.status);
     }
 
     if (payload.ok === false) {
@@ -107,6 +117,6 @@ export async function fetchResultsBySession(
     if (error instanceof Error) {
       throw error;
     }
-    throw new Error("Failed to fetch results");
+    throw new ResultsApiError("Failed to fetch results");
   }
 }


### PR DESCRIPTION
## Summary
- move the results page onto a React Query flow, including realtime Supabase invalidation, to surface new scoring data without manual reloads
- add shared query keys and clear cached results after assessment finalization or link rotation
- harden the results fetcher error typing and update the results page contract tests to provide a QueryClient and stub realtime

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cee039fc24832a9b92ba8accafa8e5