### PR TITLE
Ensure Supabase edge functions enforce JWT auth for results and linking

### DIFF
--- a/src/lib/authSession.ts
+++ b/src/lib/authSession.ts
@@ -1,0 +1,20 @@
+import supabase from "@/lib/supabaseClient";
+
+export async function getCurrentAccessToken(): Promise<string | null> {
+  try {
+    const { data: sessionData } = await supabase.auth.getSession();
+    return sessionData?.session?.access_token ?? null;
+  } catch (error) {
+    console.warn("Failed to load Supabase session", error);
+    return null;
+  }
+}
+
+export async function buildAuthHeaders(): Promise<Record<string, string>> {
+  const token = await getCurrentAccessToken();
+  if (!token) {
+    return {};
+  }
+
+  return { Authorization: `Bearer ${token}` };
+}

--- a/supabase/functions/get-results-by-session/index.ts
+++ b/supabase/functions/get-results-by-session/index.ts
@@ -1,184 +1,264 @@
 import { serve } from "https://deno.land/std@0.177.0/http/server.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { createClient, type SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2";
 
-const corsHeaders = {
-  "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
-  "Access-Control-Allow-Methods": "POST, OPTIONS",
-  "Content-Type": "application/json",
-};
+type AuthContext = "token" | "owner";
 
-function jsonResponse(body: unknown, status = 200) {
-  return new Response(JSON.stringify(body), { 
-    status, 
-    headers: corsHeaders 
+const defaultOrigin = Deno.env.get("RESULTS_ALLOWED_ORIGIN") ?? "https://prismpersonality.com";
+const allowedOrigins = new Set([
+  defaultOrigin,
+  "https://prismpersonality.com",
+  "https://www.prismpersonality.com",
+  "http://localhost:3000",
+  "http://127.0.0.1:3000",
+]);
+
+function resolveOrigin(req: Request): string {
+  const origin = req.headers.get("origin");
+  if (origin && allowedOrigins.has(origin)) {
+    return origin;
+  }
+  return defaultOrigin;
+}
+
+function buildCorsHeaders(origin: string): Record<string, string> {
+  return {
+    "Access-Control-Allow-Origin": origin,
+    "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+    "Access-Control-Allow-Methods": "POST, OPTIONS",
+    Vary: "Origin",
+  };
+}
+
+function jsonResponse(origin: string, body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      ...buildCorsHeaders(origin),
+      "Content-Type": "application/json",
+      "Cache-Control": "no-store",
+    },
   });
 }
 
-async function assertOwner(service: any, sessionId: string, userId: string) {
-  const { data, error } = await service.from("assessment_sessions").select("user_id").eq("id", sessionId).maybeSingle();
-  if (error) throw new Error(`session_lookup_failed: ${error.message}`);
-  if (!data) return jsonResponse({ ok: false, error: "session not found" }, 404);
-  if (!data.user_id || data.user_id !== userId) return jsonResponse({ ok: false, error: "forbidden" }, 403);
-  return null;
+function createAuthedClient(
+  supabaseUrl: string,
+  anonKey: string,
+  authorization: string
+): SupabaseClient {
+  return createClient(supabaseUrl, anonKey, {
+    global: {
+      headers: {
+        Authorization: authorization,
+      },
+    },
+    auth: { persistSession: false },
+  });
 }
 
 serve(async (req) => {
-  if (req.method === "OPTIONS") return new Response(null, { headers: corsHeaders });
-  
+  const origin = resolveOrigin(req);
+
+  if (req.method === "OPTIONS") {
+    return new Response("ok", {
+      headers: {
+        ...buildCorsHeaders(origin),
+        "Cache-Control": "no-store",
+      },
+    });
+  }
+
   try {
     const body = await req.json();
-    const sessionId = body.session_id ?? body.sessionId;
-    const shareToken = body.share_token ?? body.shareToken ?? null;
-    
-    console.log(JSON.stringify({
-      evt: 'results_v2_start',
-      session_id: sessionId,
-      has_token: !!shareToken,
-      timestamp: new Date().toISOString()
-    }));
-    
-    if (!sessionId) return jsonResponse({ ok: false, error: "session_id required" }, 400);
+    const sessionId: string | undefined = body.session_id ?? body.sessionId;
+    const shareToken: string | null = body.share_token ?? body.shareToken ?? null;
 
-    const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
-    const supabaseServiceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
-    const supabaseAnonKey = Deno.env.get("SUPABASE_ANON_KEY")!;
-    
-    const serviceClient = createClient(supabaseUrl, supabaseServiceKey, {
-      auth: { persistSession: false }
+    console.log(
+      JSON.stringify({
+        evt: "results_v2_start",
+        session_id: sessionId,
+        has_token: !!shareToken,
+        timestamp: new Date().toISOString(),
+      }),
+    );
+
+    if (!sessionId) {
+      return jsonResponse(origin, { ok: false, error: "session_id required" }, 400);
+    }
+
+    const supabaseUrl = Deno.env.get("SUPABASE_URL");
+    const serviceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+    const anonKey = Deno.env.get("SUPABASE_ANON_KEY");
+
+    if (!supabaseUrl || !serviceKey || !anonKey) {
+      console.error("Missing Supabase configuration");
+      return jsonResponse(origin, { ok: false, error: "configuration error" }, 500);
+    }
+
+    const serviceClient = createClient(supabaseUrl, serviceKey, {
+      auth: { persistSession: false },
     });
 
-    // Handle authentication: share token OR owner
-    let authContext: 'token' | 'owner' = 'token';
-    
+    let dataClient: SupabaseClient = serviceClient;
+    let authContext: AuthContext = "token";
+
     if (!shareToken) {
-      // No token → require owner authentication
-      const authHeader = req.headers.get("Authorization") || "";
-      if (!authHeader.startsWith("Bearer ")) {
-        return jsonResponse({ ok: false, error: "share token required" }, 401);
+      const authorization = req.headers.get("authorization");
+      if (!authorization || !authorization.startsWith("Bearer ")) {
+        return jsonResponse(origin, { ok: false, error: "authorization required" }, 401);
       }
 
-      const jwt = authHeader.slice(7);
-      const authedClient = createClient(supabaseUrl, supabaseAnonKey, {
-        global: { headers: { Authorization: `Bearer ${jwt}` } },
-        auth: { persistSession: false }
-      });
+      const authedClient = createAuthedClient(supabaseUrl, anonKey, authorization);
+      const { data: userResponse, error: userError } = await authedClient.auth.getUser();
 
-      const { data: userResponse } = await authedClient.auth.getUser();
+      if (userError) {
+        console.error("Failed to load authenticated user", userError);
+        return jsonResponse(origin, { ok: false, error: "unauthorized" }, 401);
+      }
+
       const user = userResponse?.user;
-      
       if (!user) {
-        console.error("No authenticated user found");
-        return jsonResponse({ ok: false, error: "unauthorized" }, 401);
+        return jsonResponse(origin, { ok: false, error: "unauthorized" }, 401);
       }
-      
-      // Verify user owns this session
-      const ownerCheck = await assertOwner(serviceClient, sessionId, user.id);
-      if (ownerCheck) return ownerCheck; // 403/404 already returned
-      
-      authContext = 'owner';
+
+      const { data: sessionRow, error: sessionError } = await authedClient
+        .from("assessment_sessions")
+        .select("id")
+        .eq("id", sessionId)
+        .maybeSingle();
+
+      if (sessionError) {
+        console.error("session lookup failed", sessionError);
+        return jsonResponse(origin, { ok: false, error: "session lookup failed" }, 500);
+      }
+
+      if (!sessionRow) {
+        return jsonResponse(origin, { ok: false, error: "forbidden" }, 403);
+      }
+
+      dataClient = authedClient;
+      authContext = "owner";
     } else {
-      // Validate share token
-      const { data: sess } = await serviceClient
+      const { data: sess, error: sessionError } = await serviceClient
         .from("assessment_sessions")
         .select("share_token")
         .eq("id", sessionId)
         .maybeSingle();
+
+      if (sessionError) {
+        console.error("share token lookup failed", sessionError);
+        return jsonResponse(origin, { ok: false, error: "session lookup failed" }, 500);
+      }
+
       if (!sess || sess.share_token !== shareToken) {
-        return jsonResponse({ ok: false, error: "invalid token" }, 401);
+        return jsonResponse(origin, { ok: false, error: "invalid token" }, 401);
       }
     }
 
-    // Try V2 (RPC), else v1 profile fallback
     try {
-      const { data, error } = await serviceClient.rpc('get_results_v2', {
+      const { data, error } = await dataClient.rpc("get_results_v2", {
         p_session_id: sessionId,
-        p_share_token: shareToken || null
+        p_share_token: shareToken,
       });
 
-      if (!error && data && data.length > 0) {
+      if (!error && Array.isArray(data) && data.length > 0) {
         const result = data[0];
-        const { session, profile, types, functions, state } = result;
+        const { session, profile, types, functions, state } = result as Record<string, unknown>;
 
-        // Check if we have complete v2 scoring data
-        if (Array.isArray(types) && types.length === 16 && 
-            Array.isArray(functions) && functions.length === 8 && 
-            Array.isArray(state) && state.length > 0) {
-          
-          console.log(JSON.stringify({
-            evt: 'results_v2_complete',
-            session_id: sessionId,
-            auth_context: authContext,
-            types_count: types.length,
-            functions_count: functions.length,
-            state_count: state.length,
-            timestamp: new Date().toISOString()
-          }));
+        if (
+          Array.isArray(types) &&
+          types.length === 16 &&
+          Array.isArray(functions) &&
+          functions.length === 8 &&
+          Array.isArray(state) &&
+          state.length > 0
+        ) {
+          console.log(
+            JSON.stringify({
+              evt: "results_v2_complete",
+              session_id: sessionId,
+              auth_context: authContext,
+              types_count: types.length,
+              functions_count: functions.length,
+              state_count: state.length,
+              timestamp: new Date().toISOString(),
+            }),
+          );
 
-          return jsonResponse({ 
-            ok: true, 
+          return jsonResponse(origin, {
+            ok: true,
             results_version: "v2",
             session,
             profile,
             types,
             functions,
-            state
+            state,
           });
         }
       }
-    } catch (rpcError: any) {
-      console.log(JSON.stringify({
-        evt: 'results_v2_rpc_error',
-        session_id: sessionId,
-        error: rpcError.message,
-        timestamp: new Date().toISOString()
-      }));
+    } catch (rpcError) {
+      const errorMessage = rpcError instanceof Error ? rpcError.message : String(rpcError);
+      console.log(
+        JSON.stringify({
+          evt: "results_v2_rpc_error",
+          session_id: sessionId,
+          error: errorMessage,
+          timestamp: new Date().toISOString(),
+        }),
+      );
     }
 
-    // Fallback to v1 profile
-    const { data: profile, error: profErr } = await serviceClient
+    const { data: profile, error: profileError } = await dataClient
       .from("profiles")
-      .select(`
-        session_id, type_code, base_func, creative_func, top_types, top_3_fits, 
-        score_fit_raw, score_fit_calibrated, fit_band, top_gap, close_call, 
-        strengths, dimensions, blocks_norm, overlay, conf_raw, conf_calibrated, 
+      .select(
+        `
+        session_id, type_code, base_func, creative_func, top_types, top_3_fits,
+        score_fit_raw, score_fit_calibrated, fit_band, top_gap, close_call,
+        strengths, dimensions, blocks_norm, overlay, conf_raw, conf_calibrated,
         confidence, results_version, created_at
-      `)
+      `,
+      )
       .eq("session_id", sessionId)
       .maybeSingle();
 
-    if (profErr || !profile) {
-      console.log(JSON.stringify({
-        evt: 'results_fallback_missing',
-        session_id: sessionId,
-        error: profErr?.message,
-        timestamp: new Date().toISOString()
-      }));
-      return jsonResponse({ ok: false, error: "no results found" }, 404);
+    if (profileError) {
+      console.log(
+        JSON.stringify({
+          evt: "results_fallback_missing",
+          session_id: sessionId,
+          error: profileError.message,
+          timestamp: new Date().toISOString(),
+        }),
+      );
+      return jsonResponse(origin, { ok: false, error: "no results found" }, 404);
     }
 
-    console.log(JSON.stringify({
-      evt: 'results_v1_fallback',
-      session_id: sessionId,
-      auth_context: authContext,
-      timestamp: new Date().toISOString()
-    }));
+    if (!profile) {
+      return jsonResponse(origin, { ok: false, error: "no results found" }, 404);
+    }
 
-    return jsonResponse({ 
-      ok: true, 
-      results_version: profile.results_version ?? "v1.2.1", 
-      session: { id: sessionId, created_at: profile.created_at }, 
-      profile, 
-      types: null, 
-      functions: null, 
-      state: null 
+    const typedProfile = profile as Record<string, unknown>;
+
+    console.log(
+      JSON.stringify({
+        evt: "results_v1_fallback",
+        session_id: sessionId,
+        auth_context: authContext,
+        timestamp: new Date().toISOString(),
+      }),
+    );
+
+    return jsonResponse(origin, {
+      ok: true,
+      results_version: (typedProfile.results_version as string | undefined) ?? "v1.2.1",
+      session: { id: sessionId, created_at: typedProfile.created_at },
+      profile,
+      types: null,
+      functions: null,
+      state: null,
     });
-
-  } catch (error: any) {
-    console.error("Error in get-results-by-session:", error);
-    return jsonResponse({ 
-      ok: false, 
-      error: error.message || "Internal server error" 
-    }, 500);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error("Error in get-results-by-session:", message);
+    return jsonResponse(origin, { ok: false, error: message || "Internal server error" }, 500);
   }
 });

--- a/supabase/functions/link_session_to_account/index.ts
+++ b/supabase/functions/link_session_to_account/index.ts
@@ -7,33 +7,100 @@ interface LinkRequest {
   email?: string;
 }
 
-const corsHeaders = {
-  "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
-};
+const defaultOrigin = Deno.env.get("RESULTS_ALLOWED_ORIGIN") ?? "https://prismpersonality.com";
+const allowedOrigins = new Set([
+  defaultOrigin,
+  "https://prismpersonality.com",
+  "https://www.prismpersonality.com",
+  "http://localhost:3000",
+  "http://127.0.0.1:3000",
+]);
+
+function resolveOrigin(req: Request): string {
+  const origin = req.headers.get("origin");
+  if (origin && allowedOrigins.has(origin)) {
+    return origin;
+  }
+  return defaultOrigin;
+}
+
+function buildCorsHeaders(origin: string): Record<string, string> {
+  return {
+    "Access-Control-Allow-Origin": origin,
+    "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+    "Access-Control-Allow-Methods": "POST, OPTIONS",
+    Vary: "Origin",
+  };
+}
+
+function jsonResponse(origin: string, body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      ...buildCorsHeaders(origin),
+      "Content-Type": "application/json",
+      "Cache-Control": "no-store",
+    },
+  });
+}
 
 serve(async (req) => {
+  const origin = resolveOrigin(req);
+
   // Handle CORS preflight requests
   if (req.method === "OPTIONS") {
-    return new Response(null, { headers: corsHeaders });
+    return new Response("ok", {
+      headers: {
+        ...buildCorsHeaders(origin),
+        "Cache-Control": "no-store",
+      },
+    });
   }
 
   try {
-    const { session_id, user_id, email }: LinkRequest = await req.json();
-    
-    if (!session_id || !user_id) {
-      return new Response(
-        JSON.stringify({ success: false, error: "missing_params" }),
-        { 
-          status: 400, 
-          headers: { ...corsHeaders, "Content-Type": "application/json" } 
-        }
-      );
+    const authorization = req.headers.get("authorization");
+    if (!authorization || !authorization.startsWith("Bearer ")) {
+      return jsonResponse(origin, { success: false, error: "unauthorized" }, 401);
     }
 
-    const supabaseUrl = Deno.env.get("SUPABASE_URL")!;
-    const supabaseServiceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
-    const supabase = createClient(supabaseUrl, supabaseServiceKey);
+    const supabaseUrl = Deno.env.get("SUPABASE_URL");
+    const serviceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+    const anonKey = Deno.env.get("SUPABASE_ANON_KEY");
+
+    if (!supabaseUrl || !serviceKey || !anonKey) {
+      console.error("Missing Supabase configuration");
+      return jsonResponse(origin, { success: false, error: "configuration_error" }, 500);
+    }
+
+    const authedClient = createClient(supabaseUrl, anonKey, {
+      global: { headers: { Authorization: authorization } },
+      auth: { persistSession: false },
+    });
+
+    const { data: userResult, error: userError } = await authedClient.auth.getUser();
+    if (userError) {
+      console.error("Failed to load authenticated user", userError);
+      return jsonResponse(origin, { success: false, error: "unauthorized" }, 401);
+    }
+
+    const authUser = userResult?.user;
+    if (!authUser) {
+      return jsonResponse(origin, { success: false, error: "unauthorized" }, 401);
+    }
+
+    const { session_id, user_id, email }: LinkRequest = await req.json();
+
+    if (!session_id || !user_id) {
+      return jsonResponse(origin, { success: false, error: "missing_params" }, 400);
+    }
+
+    if (authUser.id !== user_id) {
+      return jsonResponse(origin, { success: false, error: "user_mismatch" }, 403);
+    }
+
+    const supabase = createClient(supabaseUrl, serviceKey, {
+      auth: { persistSession: false },
+    });
 
     // Check current session state
     const { data: sess } = await supabase
@@ -43,64 +110,34 @@ serve(async (req) => {
       .maybeSingle();
 
     if (!sess) {
-      return new Response(
-        JSON.stringify({ success: false, error: "not_found" }),
-        { 
-          status: 404, 
-          headers: { ...corsHeaders, "Content-Type": "application/json" } 
-        }
-      );
+      return jsonResponse(origin, { success: false, error: "not_found" }, 404);
     }
 
     // Already linked to same user - no-op
     if (sess.user_id && sess.user_id === user_id) {
-      return new Response(
-        JSON.stringify({ success: true, note: "already linked" }),
-        { headers: { ...corsHeaders, "Content-Type": "application/json" } }
-      );
+      return jsonResponse(origin, { success: true, note: "already linked" });
     }
 
     // Already linked to different user - conflict
     if (sess.user_id && sess.user_id !== user_id) {
-      return new Response(
-        JSON.stringify({ success: false, code: "ALREADY_LINKED" }),
-        { 
-          status: 409, 
-          headers: { ...corsHeaders, "Content-Type": "application/json" } 
-        }
-      );
+      return jsonResponse(origin, { success: false, code: "ALREADY_LINKED" }, 409);
     }
 
     // Link the session
     const { error: updErr } = await supabase
       .from("assessment_sessions")
-      .update({ user_id, email })
+      .update({ user_id, email: email ?? authUser.email ?? null })
       .eq("id", session_id);
 
     if (updErr) {
       console.error("Update error:", updErr);
-      return new Response(
-        JSON.stringify({ success: false, error: "link_failed" }),
-        { 
-          status: 500, 
-          headers: { ...corsHeaders, "Content-Type": "application/json" } 
-        }
-      );
+      return jsonResponse(origin, { success: false, error: "link_failed" }, 500);
     }
 
-    return new Response(
-      JSON.stringify({ success: true }),
-      { headers: { ...corsHeaders, "Content-Type": "application/json" } }
-    );
+    return jsonResponse(origin, { success: true });
 
   } catch (e: any) {
     console.error("link_session_to_account error:", e?.message || e);
-    return new Response(
-      JSON.stringify({ success: false, error: e?.message || "link_failed" }),
-      { 
-        status: 500, 
-        headers: { ...corsHeaders, "Content-Type": "application/json" } 
-      }
-    );
+    return jsonResponse(origin, { success: false, error: e?.message || "link_failed" }, 500);
   }
 });

--- a/tests/linkSessionToAccount.test.ts
+++ b/tests/linkSessionToAccount.test.ts
@@ -1,8 +1,33 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+
+import supabase from '../src/lib/supabaseClient';
 import { ensureSessionLinked, linkSessionToAccount } from '../src/services/sessionLinking';
 
 const originalFetch = globalThis.fetch;
+const originalGetUser = supabase.auth.getUser.bind(supabase.auth);
+const originalGetSession = supabase.auth.getSession.bind(supabase.auth);
+const originalInvoke = supabase.functions.invoke.bind(supabase.functions);
+
+const TEST_USER_ID = 'test-user';
+const TEST_EMAIL = 'test-user@example.com';
+
+function primeAuthMocks() {
+  (supabase.auth as any).getUser = async () => ({
+    data: { user: { id: TEST_USER_ID, email: TEST_EMAIL } },
+    error: null,
+  });
+  (supabase.auth as any).getSession = async () => ({
+    data: { session: { access_token: 'test-token' } },
+    error: null,
+  });
+}
+
+test.beforeEach(() => {
+  globalThis.fetch = originalFetch;
+  primeAuthMocks();
+  (supabase.functions as any).invoke = async () => ({ data: null, error: { status: 500 } });
+});
 
 test('ensureSessionLinked sends POST with payload and returns true on 200', async () => {
   const calls: Array<{ url: string; body: any }> = [];
@@ -12,27 +37,27 @@ test('ensureSessionLinked sends POST with payload and returns true on 200', asyn
     return new Response(JSON.stringify({ success: true }), { status: 200 });
   }) as typeof fetch;
 
-  const result = await ensureSessionLinked({ sessionId: 's1', userId: 'u1', email: 'a@b.com' });
+  const result = await ensureSessionLinked({ sessionId: 's1', userId: TEST_USER_ID, email: 'a@b.com' });
 
   assert.equal(result, true);
   assert.equal(calls.length, 1);
   assert.ok(calls[0].url.endsWith('/link_session_to_account'));
   assert.deepEqual(calls[0].body, {
     session_id: 's1',
-    user_id: 'u1',
+    user_id: TEST_USER_ID,
     email: 'a@b.com',
   });
 });
 
 test('ensureSessionLinked treats 409 as success', async () => {
   globalThis.fetch = (async () => new Response('{}', { status: 409 })) as typeof fetch;
-  const result = await ensureSessionLinked({ sessionId: 's2', userId: 'u2' });
+  const result = await ensureSessionLinked({ sessionId: 's2', userId: TEST_USER_ID });
   assert.equal(result, true);
 });
 
 test('ensureSessionLinked returns false on server error', async () => {
   globalThis.fetch = (async () => new Response('{}', { status: 500 })) as typeof fetch;
-  const result = await ensureSessionLinked({ sessionId: 's3', userId: 'u3' });
+  const result = await ensureSessionLinked({ sessionId: 's3', userId: TEST_USER_ID });
   assert.equal(result, false);
 });
 
@@ -40,7 +65,7 @@ test('ensureSessionLinked returns false on network error', async () => {
   globalThis.fetch = (async () => {
     throw new Error('network');
   }) as typeof fetch;
-  const result = await ensureSessionLinked({ sessionId: 's4', userId: 'u4' });
+  const result = await ensureSessionLinked({ sessionId: 's4', userId: TEST_USER_ID });
   assert.equal(result, false);
 });
 
@@ -50,18 +75,21 @@ test('linkSessionToAccount wraps ensureSessionLinked', async () => {
     called++;
     return new Response('{}', { status: 200 });
   }) as typeof fetch;
-  const res = await linkSessionToAccount({} as any, 's5', 'u5', 'c@d.com');
+  const res = await linkSessionToAccount({} as any, 's5', TEST_USER_ID, 'c@d.com');
   assert.deepEqual(res, { ok: true });
   assert.equal(called, 1);
 });
 
 test('linkSessionToAccount returns error payload on failure', async () => {
   globalThis.fetch = (async () => new Response('{}', { status: 500 })) as typeof fetch;
-  const res = await linkSessionToAccount({} as any, 's6', 'u6');
+  const res = await linkSessionToAccount({} as any, 's6', TEST_USER_ID);
   assert.equal(res.ok, false);
   assert.ok(res instanceof Object && 'error' in res);
 });
 
 test.after(() => {
   globalThis.fetch = originalFetch;
+  (supabase.auth as any).getUser = originalGetUser;
+  (supabase.auth as any).getSession = originalGetSession;
+  (supabase.functions as any).invoke = originalInvoke;
 });

--- a/tests/linkSessionsToUser.test.ts
+++ b/tests/linkSessionsToUser.test.ts
@@ -1,8 +1,33 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+
+import supabase from '../src/lib/supabaseClient';
 import { ensureSessionLinked } from '../src/services/sessionLinking';
 
 const originalFetch = globalThis.fetch;
+const originalGetUser = supabase.auth.getUser.bind(supabase.auth);
+const originalGetSession = supabase.auth.getSession.bind(supabase.auth);
+const originalInvoke = supabase.functions.invoke.bind(supabase.functions);
+
+const TEST_USER_ID = 'test-user';
+const TEST_EMAIL = 'test-user@example.com';
+
+function primeAuthMocks() {
+  (supabase.auth as any).getUser = async () => ({
+    data: { user: { id: TEST_USER_ID, email: TEST_EMAIL } },
+    error: null,
+  });
+  (supabase.auth as any).getSession = async () => ({
+    data: { session: { access_token: 'test-token' } },
+    error: null,
+  });
+}
+
+test.beforeEach(() => {
+  globalThis.fetch = originalFetch;
+  primeAuthMocks();
+  (supabase.functions as any).invoke = async () => ({ data: null, error: { status: 500 } });
+});
 
 test('ensureSessionLinked short-circuits without session id', async () => {
   globalThis.fetch = (async () => {
@@ -26,11 +51,14 @@ test('ensureSessionLinked handles null email gracefully', async () => {
     captured = init?.body ? JSON.parse(String(init.body)) : null;
     return new Response('{}', { status: 200 });
   }) as typeof fetch;
-  const result = await ensureSessionLinked({ sessionId: 's2', userId: 'u2' });
+  const result = await ensureSessionLinked({ sessionId: 's2', userId: TEST_USER_ID });
   assert.equal(result, true);
   assert.equal(captured.email, null);
 });
 
 test.after(() => {
   globalThis.fetch = originalFetch;
+  (supabase.auth as any).getUser = originalGetUser;
+  (supabase.auth as any).getSession = originalGetSession;
+  (supabase.functions as any).invoke = originalInvoke;
 });


### PR DESCRIPTION
## Summary
- add a shared helper for attaching Supabase access tokens and use it when invoking the results edge function
- harden the get-results-by-session and link_session_to_account edge functions with explicit CORS handling, JWT verification, and cache-control headers
- update session linking flows and tests to require authenticated users and forward Authorization headers consistently

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cee45149c8832aa356daa03b63583c