### PR TITLE
Ensure Supabase edge fetches include anon key

### DIFF
--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -11,6 +11,9 @@ const fallbackAnon =
 const url = (viteEnv.VITE_SUPABASE_URL as string | undefined) ?? nextPublicUrl ?? fallbackUrl;
 const anon = (viteEnv.VITE_SUPABASE_ANON_KEY as string | undefined) ?? nextPublicAnon ?? fallbackAnon;
 
+export const SUPABASE_URL = url;
+export const SUPABASE_ANON_KEY = anon;
+
 const getStorage = (): Storage => {
   if (typeof window !== "undefined" && window.localStorage) {
     return window.localStorage;

--- a/src/services/resultsApi.ts
+++ b/src/services/resultsApi.ts
@@ -1,6 +1,7 @@
 import supabase from "@/lib/supabaseClient";
 import { buildAuthHeaders } from "@/lib/authSession";
 import { IS_PREVIEW } from "@/lib/env";
+import { buildEdgeRequestHeaders, resolveSupabaseFunctionsBase } from "@/services/supabaseEdge";
 
 export class ResultsApiError extends Error {
   status?: number;
@@ -10,23 +11,6 @@ export class ResultsApiError extends Error {
     this.name = "ResultsApiError";
     this.status = status;
   }
-}
-
-let cachedFunctionsBase: string | null = null;
-
-function resolveFunctionsBase(): string {
-  if (cachedFunctionsBase) return cachedFunctionsBase;
-
-  const envUrl =
-    (typeof process !== "undefined" ? process.env?.NEXT_PUBLIC_SUPABASE_FUNCTIONS_URL : undefined) ??
-    (typeof import.meta !== "undefined" && (import.meta as any).env?.VITE_SUPABASE_URL
-      ? `${(import.meta as any).env.VITE_SUPABASE_URL}/functions/v1`
-      : undefined);
-
-  const resolved = envUrl ?? "https://gnkuikentdtnatazeriu.supabase.co/functions/v1";
-
-  cachedFunctionsBase = resolved;
-  return cachedFunctionsBase;
 }
 
 export type ResultsFetchPayload = Record<string, any>;
@@ -57,11 +41,11 @@ export async function fetchResultsBySession(
     throw new Error("sessionId is required");
   }
 
-  const url = `${resolveFunctionsBase()}/get-results-by-session`;
-  const headers: Record<string, string> = {
+  const url = `${resolveSupabaseFunctionsBase()}/get-results-by-session`;
+  const headers = buildEdgeRequestHeaders({
     "Content-Type": "application/json",
     "Cache-Control": "no-store",
-  };
+  });
 
   const body: Record<string, unknown> = { session_id: sessionId };
 

--- a/src/services/supabaseEdge.ts
+++ b/src/services/supabaseEdge.ts
@@ -1,0 +1,59 @@
+import { SUPABASE_ANON_KEY, SUPABASE_URL } from "@/lib/supabaseClient";
+
+const viteEnv = (typeof import.meta !== "undefined" ? ((import.meta as any).env ?? {}) : {}) as Record<string, unknown>;
+const nodeEnv = (typeof process !== "undefined" ? process.env ?? {} : {}) as Record<string, string | undefined>;
+
+let cachedFunctionsBase: string | null = null;
+
+function normalizeBaseUrl(raw: string | null | undefined): string | null {
+  if (!raw) return null;
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  if (trimmed.endsWith("/functions/v1")) {
+    return trimmed;
+  }
+  return `${trimmed.replace(/\/$/, "")}/functions/v1`;
+}
+
+function resolveEnvFunctionsUrl(): string | null {
+  const explicit =
+    nodeEnv.NEXT_PUBLIC_SUPABASE_FUNCTIONS_URL ??
+    nodeEnv.VITE_SUPABASE_FUNCTIONS_URL ??
+    (viteEnv.VITE_SUPABASE_FUNCTIONS_URL as string | undefined) ??
+    null;
+  return normalizeBaseUrl(explicit);
+}
+
+export function resolveSupabaseFunctionsBase(): string {
+  if (cachedFunctionsBase) return cachedFunctionsBase;
+
+  const fromEnv = resolveEnvFunctionsUrl();
+  if (fromEnv) {
+    cachedFunctionsBase = fromEnv;
+    return cachedFunctionsBase;
+  }
+
+  const fallback = `${SUPABASE_URL.replace(/\/$/, "")}/functions/v1`;
+  cachedFunctionsBase = fallback;
+  return cachedFunctionsBase;
+}
+
+export function buildEdgeRequestHeaders(
+  overrides?: Record<string, string | undefined>
+): Record<string, string> {
+  const base: Record<string, string> = {
+    apikey: SUPABASE_ANON_KEY,
+    "x-client-info": "prism-web-edge",
+  };
+
+  if (!overrides) {
+    return base;
+  }
+
+  for (const [key, value] of Object.entries(overrides)) {
+    if (value === undefined) continue;
+    base[key] = value;
+  }
+
+  return base;
+}


### PR DESCRIPTION
## Summary
- export Supabase configuration constants and add a shared edge helper to resolve the functions base URL
- ensure results fetching and session linking POSTs include the anon key apikey header alongside auth when present
- strengthen results and session linking tests to assert the expected headers are sent

## Testing
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cee9be8ce8832abd22612528a6c816