### PR TITLE
Enforce finalizeAssessment orchestration and navigation

### DIFF
--- a/supabase/functions/_shared/finalizeAssessmentCore.ts
+++ b/supabase/functions/_shared/finalizeAssessmentCore.ts
@@ -1,0 +1,219 @@
+import { RESULTS_VERSION } from "./resultsVersion.ts";
+
+export interface ProfileRow {
+  id: string;
+  session_id: string;
+  share_token?: string;
+  fc_answered_ct?: number | null;
+  top_gap?: number | null;
+  conf_calibrated?: number | null;
+  validity_status?: string | null;
+  type_code?: string | null;
+  results_version?: string | null;
+  version?: string | null;
+  [key: string]: unknown;
+}
+
+export interface SessionRow {
+  id: string;
+  share_token: string | null;
+  share_token_expires_at: string | null;
+  completed_at: string | null;
+  finalized_at: string | null;
+  completed_questions: number | null;
+  status: string | null;
+  updated_at: string | null;
+}
+
+export interface ScorePrismSuccess {
+  status: "success";
+  profile: ProfileRow;
+}
+
+export type ScorePrismResult = ScorePrismSuccess | { status: string; error?: string } | null | undefined;
+
+export interface FinalizeAssessmentDeps {
+  acquireLock(sessionId: string): Promise<() => void>;
+  getProfile(sessionId: string): Promise<ProfileRow | null>;
+  normalizeProfile(profile: ProfileRow): Promise<ProfileRow>;
+  scoreFcSession(sessionId: string): Promise<void>;
+  scorePrism(sessionId: string): Promise<ScorePrismResult>;
+  getSession(sessionId: string): Promise<SessionRow | null>;
+  upsertSession(sessionId: string, patch: Partial<SessionRow>): Promise<void>;
+  generateShareToken(): string;
+  buildResultsUrl(baseUrl: string, sessionId: string, token: string): string;
+  now(): Date;
+  log(payload: Record<string, unknown>): void;
+}
+
+export interface FinalizeAssessmentInput {
+  sessionId: string;
+  responses?: unknown;
+  siteUrl: string;
+}
+
+export interface FinalizeAssessmentOutput {
+  ok: true;
+  profile: ProfileRow;
+  share_token: string;
+  results_url: string;
+  results_version: string;
+}
+
+function toResponsesCount(responses: unknown): number | null {
+  if (Array.isArray(responses)) {
+    return responses.length;
+  }
+  return null;
+}
+
+function computeShareExpiry(now: Date): string {
+  const ttlMs = 30 * 24 * 60 * 60 * 1000;
+  return new Date(now.getTime() + ttlMs).toISOString();
+}
+
+function computeCompletedQuestions(responsesCount: number | null, profile: ProfileRow): number | null {
+  if (typeof responsesCount === "number") {
+    return responsesCount;
+  }
+  const fcAnswered = profile.fc_answered_ct;
+  if (typeof fcAnswered === "number" && Number.isFinite(fcAnswered)) {
+    return fcAnswered;
+  }
+  return null;
+}
+
+function flagFcUsed(profile: ProfileRow): boolean {
+  const answered = profile.fc_answered_ct;
+  return typeof answered === "number" ? answered > 0 : false;
+}
+
+export class FinalizeAssessmentError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "FinalizeAssessmentError";
+  }
+}
+
+function assertSuccessfulPrism(result: ScorePrismResult, sessionId: string): ScorePrismSuccess {
+  if (!result || typeof result !== "object") {
+    throw new FinalizeAssessmentError(`score_prism returned invalid response for session ${sessionId}`);
+  }
+  if (result.status !== "success" || !("profile" in result) || !result.profile) {
+    const reason = "error" in result && result.error ? result.error : "unknown";
+    throw new FinalizeAssessmentError(`score_prism failed for session ${sessionId}: ${reason}`);
+  }
+  return result;
+}
+
+async function ensureSessionExists(session: SessionRow | null, sessionId: string): Promise<SessionRow> {
+  if (!session) {
+    throw new FinalizeAssessmentError(`assessment_session ${sessionId} not found`);
+  }
+  return session;
+}
+
+export async function finalizeAssessmentCore(
+  deps: FinalizeAssessmentDeps,
+  input: FinalizeAssessmentInput,
+): Promise<FinalizeAssessmentOutput> {
+  const { sessionId, responses, siteUrl } = input;
+  const release = await deps.acquireLock(sessionId);
+  try {
+    const session = await deps.getSession(sessionId);
+    const existingProfile = await deps.getProfile(sessionId);
+    const responsesCount = toResponsesCount(responses);
+
+    if (existingProfile) {
+      const normalized = await deps.normalizeProfile(existingProfile);
+      const ensuredSession = await ensureSessionExists(session, sessionId);
+      const now = deps.now();
+      const shareToken = ensuredSession.share_token || deps.generateShareToken();
+      const shareExpiry = ensuredSession.share_token_expires_at || computeShareExpiry(now);
+      const completedAt = ensuredSession.completed_at || now.toISOString();
+      const finalizedAt = ensuredSession.finalized_at || completedAt;
+      const completedQuestions = computeCompletedQuestions(responsesCount, normalized);
+
+      await deps.upsertSession(sessionId, {
+        share_token: shareToken,
+        share_token_expires_at: shareExpiry,
+        completed_at: completedAt,
+        finalized_at: finalizedAt,
+        completed_questions: completedQuestions,
+        status: "completed",
+        updated_at: now.toISOString(),
+      });
+
+      const resultsUrl = deps.buildResultsUrl(siteUrl, sessionId, shareToken);
+      deps.log({
+        evt: "finalize.complete",
+        path: "cache_hit",
+        sessionId,
+        RESULTS_VERSION,
+        fc_used: flagFcUsed(normalized),
+        top_type: normalized.type_code ?? null,
+        top_gap: normalized.top_gap ?? null,
+        conf_calibrated: normalized.conf_calibrated ?? null,
+        validity_status: normalized.validity_status ?? null,
+      });
+
+      return {
+        ok: true,
+        profile: normalized,
+        share_token: shareToken,
+        results_url: resultsUrl,
+        results_version: RESULTS_VERSION,
+      };
+    }
+
+    // No profile exists yet — run scoring flow.
+    try {
+      await deps.scoreFcSession(sessionId);
+    } catch (error) {
+      deps.log({ evt: "finalize.fc_error", sessionId, error: error instanceof Error ? error.message : String(error) });
+    }
+
+    const prismResult = assertSuccessfulPrism(await deps.scorePrism(sessionId), sessionId);
+    const normalized = await deps.normalizeProfile(prismResult.profile);
+    const ensuredSession = await ensureSessionExists(await deps.getSession(sessionId), sessionId);
+    const now = deps.now();
+    const shareToken = ensuredSession.share_token || deps.generateShareToken();
+    const shareExpiry = ensuredSession.share_token_expires_at || computeShareExpiry(now);
+    const completedAt = ensuredSession.completed_at || now.toISOString();
+    const finalizedAt = ensuredSession.finalized_at || completedAt;
+    const completedQuestions = computeCompletedQuestions(responsesCount, normalized);
+
+    await deps.upsertSession(sessionId, {
+      share_token: shareToken,
+      share_token_expires_at: shareExpiry,
+      completed_at: completedAt,
+      finalized_at: finalizedAt,
+      completed_questions: completedQuestions,
+      status: "completed",
+      updated_at: now.toISOString(),
+    });
+
+    const resultsUrl = deps.buildResultsUrl(siteUrl, sessionId, shareToken);
+    deps.log({
+      evt: "finalize.complete",
+      path: "scored",
+      sessionId,
+      RESULTS_VERSION,
+      fc_used: flagFcUsed(normalized),
+      top_type: normalized.type_code ?? null,
+      top_gap: normalized.top_gap ?? null,
+      conf_calibrated: normalized.conf_calibrated ?? null,
+      validity_status: normalized.validity_status ?? null,
+    });
+
+    return {
+      ok: true,
+      profile: normalized,
+      share_token: shareToken,
+      results_url: resultsUrl,
+      results_version: RESULTS_VERSION,
+    };
+  } finally {
+    release();
+  }
+}

--- a/tests/finalizeAssessment.core.test.ts
+++ b/tests/finalizeAssessment.core.test.ts
@@ -1,0 +1,114 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { finalizeAssessmentCore } from "../supabase/functions/_shared/finalizeAssessmentCore.ts";
+import { RESULTS_VERSION } from "../supabase/functions/_shared/resultsVersion.ts";
+
+type MockProfile = {
+  id: string;
+  session_id: string;
+  fc_answered_ct?: number | null;
+  type_code?: string | null;
+  top_gap?: number | null;
+  conf_calibrated?: number | null;
+  validity_status?: string | null;
+  results_version?: string | null;
+  version?: string | null;
+};
+
+type MockSession = {
+  id: string;
+  share_token: string | null;
+  share_token_expires_at: string | null;
+  completed_at: string | null;
+  finalized_at: string | null;
+  completed_questions: number | null;
+  status: string | null;
+  updated_at: string | null;
+};
+
+test("finalizeAssessmentCore is idempotent and logs cache path", async () => {
+  const logs: Record<string, unknown>[] = [];
+  const now = new Date("2024-01-01T00:00:00.000Z");
+  let profileStore: MockProfile | null = null;
+  let sessionStore: MockSession = {
+    id: "sess-1",
+    share_token: null,
+    share_token_expires_at: null,
+    completed_at: null,
+    finalized_at: null,
+    completed_questions: null,
+    status: null,
+    updated_at: null,
+  };
+  let prismCalls = 0;
+
+  const deps = {
+    acquireLock: async () => () => {},
+    getProfile: async () => profileStore,
+    normalizeProfile: async (profile: MockProfile) => {
+      profileStore = {
+        ...profile,
+        results_version: RESULTS_VERSION,
+        version: RESULTS_VERSION,
+      };
+      return profileStore;
+    },
+    scoreFcSession: async () => {
+      /* no-op */
+    },
+    scorePrism: async () => {
+      prismCalls += 1;
+      const created: MockProfile = {
+        id: "profile-1",
+        session_id: "sess-1",
+        fc_answered_ct: 90,
+        type_code: "LII",
+        top_gap: 0.42,
+        conf_calibrated: 0.71,
+        validity_status: "valid",
+      };
+      profileStore = created;
+      return { status: "success", profile: created };
+    },
+    getSession: async () => sessionStore,
+    upsertSession: async (_sessionId: string, patch: Partial<MockSession>) => {
+      sessionStore = { ...sessionStore, ...patch };
+    },
+    generateShareToken: () => {
+      const token = sessionStore.share_token ?? "token-123";
+      sessionStore = { ...sessionStore, share_token: token };
+      return token;
+    },
+    buildResultsUrl: (_base: string, sessionId: string, token: string) => `/results/${sessionId}?t=${token}`,
+    now: () => now,
+    log: (payload: Record<string, unknown>) => {
+      logs.push(payload);
+    },
+  } as const;
+
+  const first = await finalizeAssessmentCore(deps, {
+    sessionId: "sess-1",
+    siteUrl: "https://example.com",
+    responses: new Array(90).fill({}),
+  });
+
+  assert.equal(first.ok, true);
+  assert.equal(first.profile.results_version, RESULTS_VERSION);
+  assert.equal(first.share_token, "token-123");
+  assert.equal(first.results_url, "/results/sess-1?t=token-123");
+  assert.equal(first.results_version, RESULTS_VERSION);
+  assert.equal(prismCalls, 1);
+  assert.equal(logs.at(-1)?.path, "scored");
+
+  const second = await finalizeAssessmentCore(deps, {
+    sessionId: "sess-1",
+    siteUrl: "https://example.com",
+  });
+
+  assert.equal(second.ok, true);
+  assert.equal(second.profile.results_version, RESULTS_VERSION);
+  assert.equal(second.share_token, "token-123");
+  assert.equal(second.results_url, "/results/sess-1?t=token-123");
+  assert.equal(prismCalls, 1, "score_prism should not be invoked twice");
+  assert.equal(logs.at(-1)?.path, "cache_hit");
+});


### PR DESCRIPTION
## Summary
- extract finalizeAssessment orchestration into a shared core that applies per-session locking, version stamping, and structured logging
- update the edge handler and UI flows to always finalize via finalizeAssessment, reuse existing profiles, and navigate with server-provided results URLs
- expand test coverage with unit/idempotency verification and refreshed integration checks against the latest RESULTS_VERSION

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cef2dcb9c4832aabce2030ffa373ec