### PR TITLE
Add Meta DPA payload helper and tracking

### DIFF
--- a/index.html
+++ b/index.html
@@ -188,11 +188,69 @@
       }
 
       // Wrapper to attach an eventID and fbc; returns the id we used
+      const FB_LOG_DEV = (() => {
+        try {
+          const host = (window.location && window.location.hostname) || '';
+          return host === 'localhost' || host === '127.0.0.1' || host.endsWith('.local');
+        } catch (err) {
+          console.warn('fbTrack host detection failed', err);
+          return false;
+        }
+      })();
+
+      function validateFbDpaPayload(eventName, props) {
+        if (eventName !== 'AddToCart' && eventName !== 'Purchase') {
+          return true;
+        }
+
+        const hasContents = Array.isArray(props.contents) && props.contents.length > 0;
+        const hasContentIds = Array.isArray(props.content_ids) && props.content_ids.length > 0;
+        if (!hasContents && !hasContentIds) {
+          console.warn(`fbTrack ${eventName} skipped: missing contents/content_ids`, props);
+          return false;
+        }
+
+        if (!props.content_type) {
+          props.content_type = 'product';
+        }
+
+        if (eventName === 'Purchase') {
+          if (typeof props.value !== 'number' || !Number.isFinite(props.value)) {
+            console.warn(`fbTrack ${eventName} skipped: invalid value`, props);
+            return false;
+          }
+          if (typeof props.currency !== 'string' || !props.currency.trim()) {
+            console.warn(`fbTrack ${eventName} skipped: missing currency`, props);
+            return false;
+          }
+        }
+
+        return true;
+      }
+
+      function logFbPayload(eventName, props) {
+        if (!FB_LOG_DEV) return;
+        if (eventName !== 'AddToCart' && eventName !== 'Purchase') return;
+        try {
+          const snapshot = JSON.parse(JSON.stringify(props));
+          console.debug(`[fbTrack:${eventName}]`, snapshot);
+        } catch {
+          console.debug(`[fbTrack:${eventName}]`, props);
+        }
+      }
+
       window.fbTrack = function(eventName, props){
         props = props || {};
         if (!props.eventID) props.eventID = convUUID();
         const clickId = props.fbc || getFBClickId();
         if (clickId) props.fbc = `fb.1.${Date.now()}.${clickId}`;
+
+        if (!validateFbDpaPayload(eventName, props)) {
+          return '';
+        }
+
+        logFbPayload(eventName, props);
+
         if (window.fbq) {
           if (eventName === 'Custom' && props.custom_event_name) {
             fbq('trackCustom', props.custom_event_name, props);

--- a/src/components/ServiceCard.tsx
+++ b/src/components/ServiceCard.tsx
@@ -2,6 +2,10 @@
 
 import React from "react";
 import type { Service } from "@/data/services";
+import {
+  buildFacebookPayloadFromService,
+  rememberFacebookDpaPayload,
+} from "@/lib/facebook";
 
 export function ServiceCard({
   service,
@@ -14,6 +18,11 @@ export function ServiceCard({
 }) {
   const handleClick = () => {
     onSelect(service);
+    const payload = buildFacebookPayloadFromService(service);
+    rememberFacebookDpaPayload(payload);
+    if (typeof window !== "undefined" && window.fbTrack) {
+      window.fbTrack("AddToCart", payload);
+    }
     const el = document.getElementById("book");
     if (el) el.scrollIntoView({ behavior: "smooth", block: "start" });
   };

--- a/src/lib/facebook.ts
+++ b/src/lib/facebook.ts
@@ -1,0 +1,146 @@
+import type { Service } from "@/data/services";
+
+export interface FacebookProductInput {
+  id: string;
+  name: string;
+  price?: number | string;
+  currency?: string;
+  quantity?: number;
+}
+
+export interface FacebookContentItem {
+  content_id: string;
+  content_name?: string;
+  content_price?: number;
+  num_items?: number;
+}
+
+export interface FacebookDpaEventPayload {
+  content_type: "product";
+  contents: FacebookContentItem[];
+  content_ids: string[];
+  value?: number;
+  currency?: string;
+  transaction_id?: string;
+  session_id?: string;
+  [key: string]: unknown;
+}
+
+const DEFAULT_CURRENCY = "USD";
+
+function normalisePrice(value?: number | string): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return Math.round(value * 100) / 100;
+  }
+  if (typeof value === "string") {
+    const stripped = value.replace(/[^0-9.,-]+/g, "").replace(/,(?=\d{3}(?:\D|$))/g, "");
+    const parsed = Number.parseFloat(stripped.replace(/,/g, ""));
+    if (Number.isFinite(parsed)) {
+      return Math.round(parsed * 100) / 100;
+    }
+  }
+  return undefined;
+}
+
+function deriveCurrency(value?: number | string, fallback?: string): string | undefined {
+  if (typeof fallback === "string" && fallback.trim().length > 0) {
+    return fallback.trim().toUpperCase();
+  }
+  if (typeof value === "string") {
+    if (/usd/i.test(value) || value.includes("$")) return DEFAULT_CURRENCY;
+  }
+  if (typeof value === "number") {
+    return DEFAULT_CURRENCY;
+  }
+  return undefined;
+}
+
+function clonePayload(payload: FacebookDpaEventPayload): FacebookDpaEventPayload {
+  return {
+    ...payload,
+    contents: payload.contents.map((item) => ({ ...item })),
+    content_ids: [...payload.content_ids],
+  };
+}
+
+export function buildFacebookDpaPayload(product: FacebookProductInput): FacebookDpaEventPayload {
+  const quantity = product.quantity && product.quantity > 0 ? product.quantity : 1;
+  const price = normalisePrice(product.price);
+  const currency = deriveCurrency(product.price, product.currency);
+  const value = price !== undefined ? Math.round(price * quantity * 100) / 100 : undefined;
+
+  const contents: FacebookContentItem[] = [
+    {
+      content_id: product.id,
+      content_name: product.name,
+      ...(price !== undefined ? { content_price: price } : {}),
+      num_items: quantity,
+    },
+  ];
+
+  const payload: FacebookDpaEventPayload = {
+    content_type: "product",
+    contents,
+    content_ids: [product.id],
+    ...(value !== undefined ? { value } : {}),
+    ...(currency ? { currency } : {}),
+  };
+
+  return payload;
+}
+
+export function buildFacebookPayloadFromService(
+  service: Pick<Service, "id" | "title" | "price">,
+  quantity?: number,
+): FacebookDpaEventPayload {
+  return buildFacebookDpaPayload({
+    id: service.id,
+    name: service.title,
+    price: service.price,
+    quantity,
+  });
+}
+
+export function rememberFacebookDpaPayload(payload: FacebookDpaEventPayload): void {
+  if (typeof window === "undefined") return;
+  (window as WindowWithFacebookState).__lastFbDpaPayload = clonePayload(payload);
+}
+
+export function getRememberedFacebookDpaPayload(): FacebookDpaEventPayload | undefined {
+  if (typeof window === "undefined") return undefined;
+  const state = (window as WindowWithFacebookState).__lastFbDpaPayload;
+  return state ? clonePayload(state) : undefined;
+}
+
+type WindowWithFacebookState = Window & {
+  __lastFbDpaPayload?: FacebookDpaEventPayload;
+};
+
+declare global {
+  interface Window {
+    __lastFbDpaPayload?: FacebookDpaEventPayload;
+  }
+}
+
+export function mergePurchaseDetails(
+  base: FacebookDpaEventPayload | undefined,
+  value: number,
+  currency: string,
+  metadata: { transaction_id?: string; session_id?: string },
+): FacebookDpaEventPayload | undefined {
+  if (!base) return undefined;
+  const safeValue = Number.isFinite(value) ? Math.round(value * 100) / 100 : base.value;
+  const safeCurrency = typeof currency === "string" && currency.trim().length > 0
+    ? currency.trim().toUpperCase()
+    : (typeof base.currency === "string" ? String(base.currency) : DEFAULT_CURRENCY);
+  const payload: FacebookDpaEventPayload = {
+    ...base,
+    ...(safeValue !== undefined ? { value: safeValue } : {}),
+    currency: safeCurrency,
+    ...(metadata.transaction_id ? { transaction_id: metadata.transaction_id } : {}),
+    ...(metadata.session_id ? { session_id: metadata.session_id } : {}),
+  };
+  return payload;
+}
+
+export type { FacebookProductInput as FacebookProduct };

--- a/tests/facebookPayload.test.ts
+++ b/tests/facebookPayload.test.ts
@@ -1,0 +1,51 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildFacebookDpaPayload,
+  buildFacebookPayloadFromService,
+  mergePurchaseDetails,
+} from "../src/lib/facebook";
+
+test("buildFacebookDpaPayload parses numeric price strings", () => {
+  const payload = buildFacebookDpaPayload({
+    id: "sku-123",
+    name: "Sample",
+    price: "$1,200.50",
+  });
+
+  assert.equal(payload.content_type, "product");
+  assert.deepEqual(payload.content_ids, ["sku-123"]);
+  assert.equal(payload.contents[0]?.content_price, 1200.5);
+  assert.equal(payload.value, 1200.5);
+  assert.equal(payload.currency, "USD");
+  assert.equal(payload.contents[0]?.num_items, 1);
+});
+
+test("buildFacebookPayloadFromService handles quantity overrides", () => {
+  const payload = buildFacebookPayloadFromService(
+    {
+      id: "service-1",
+      title: "Service",
+      price: "$29.00",
+    },
+    2,
+  );
+
+  assert.equal(payload.contents[0]?.num_items, 2);
+  assert.equal(payload.contents[0]?.content_price, 29);
+  assert.equal(payload.value, 58);
+});
+
+test("mergePurchaseDetails injects transaction metadata", () => {
+  const base = buildFacebookDpaPayload({ id: "sku-1", name: "Test", price: "$10.00" });
+  const result = mergePurchaseDetails(base, 20, "usd", {
+    transaction_id: "txn_1",
+    session_id: "sess",
+  });
+
+  assert(result);
+  assert.equal(result?.value, 20);
+  assert.equal(result?.currency, "USD");
+  assert.equal(result?.transaction_id, "txn_1");
+  assert.equal(result?.session_id, "sess");
+});

--- a/tests/serviceCard.test.tsx
+++ b/tests/serviceCard.test.tsx
@@ -10,9 +10,11 @@ import type { Service } from "../src/data/services";
 
 afterEach(() => {
   cleanup();
+  delete (window as unknown as { fbTrack?: unknown }).fbTrack;
+  delete (window as unknown as { __lastFbDpaPayload?: unknown }).__lastFbDpaPayload;
 });
 
-test("renders Book button and triggers onSelect", () => {
+test("renders Book button, triggers onSelect, and fires AddToCart", () => {
   const svc: Service = {
     id: "daniel-speiss/personality-mapping-call",
     scope: "individuals",
@@ -30,9 +32,34 @@ test("renders Book button and triggers onSelect", () => {
     selected = s;
   };
 
+  const calls: Array<{ event: string; payload: Record<string, unknown> }> = [];
+  (window as unknown as {
+    fbTrack?: (eventName: string, payload?: Record<string, unknown>) => string;
+  }).fbTrack = (eventName, payload = {}) => {
+    calls.push({ event: eventName, payload });
+    return "evt";
+  };
+
   render(<ServiceCard service={svc} onSelect={onSelect} />);
 
   const button = screen.getByRole("button", { name: /book/i });
   fireEvent.click(button);
   assert.equal(selected, svc);
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].event, "AddToCart");
+  const payload = calls[0].payload;
+  assert.equal(payload.content_type, "product");
+  assert.deepEqual(payload.content_ids, [svc.id]);
+  assert(Array.isArray(payload.contents));
+  assert.equal(payload.contents?.[0]?.content_id, svc.id);
+  assert.equal(payload.contents?.[0]?.content_name, svc.title);
+  assert.equal(payload.contents?.[0]?.content_price, 149);
+  assert.equal(payload.value, 149);
+  assert.equal(payload.currency, "USD");
+
+  const remembered = (window as unknown as { __lastFbDpaPayload?: Record<string, unknown> })
+    .__lastFbDpaPayload;
+  assert(remembered, "expected payload to be remembered for purchase");
+  assert.deepEqual(remembered?.content_ids, [svc.id]);
 });


### PR DESCRIPTION
## Summary
- add a reusable facebook dynamic ads payload helper with persistence for purchase handoffs
- update service selection to emit AddToCart with required DPA parameters and guard fbTrack for invalid payloads
- enrich purchase tracking to include dynamic ads payload and add unit coverage for the new helpers

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cef840b22c832a91148a0abb70d404