### PR TITLE
Add consent-gated Quora tracking and CAPI support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,3 +25,8 @@ REDDIT_PIXEL_ID=
 # TikTok Events API
 TIKTOK_PIXEL_ID=
 TIKTOK_ACCESS_TOKEN=
+
+# Quora Conversions API
+QUORA_TOKEN=
+# Optional override; defaults to production pixel when unset
+QUORA_PIXEL_ID=

--- a/docs/quora-pixel.md
+++ b/docs/quora-pixel.md
@@ -1,0 +1,55 @@
+# Quora Pixel & Conversions API Integration
+
+## Overview
+- Consent-gated Quora Pixel initialised from `index.html` via `qpTrack` helper.
+- SPA-aware page view tracking pipes through `src/lib/route-tracking.ts` and `sendQuoraPageView` to keep URLs accurate.
+- Business events wired from `src/lib/analytics.ts`, `src/components/ServiceCard.tsx`, and `src/components/CalEmbed.tsx`.
+- Optional Conversions API edge function lives at `supabase/functions/quora-capi` and reuses client `conversion_id` values for dedupe.
+
+## Event Matrix
+| Event | Trigger | Key Props |
+| --- | --- | --- |
+| `ViewContent` | SPA route change & results views | `page_path`, `content_name`, `session_id`, `type_code` |
+| `GenerateLead` | Assessment start, marketing lead capture | `email`, `session_id`, `content_name` |
+| `AddToCart` | Service booking CTA click | `value`, `currency`, `contents`, `content_ids` |
+| `InitiateCheckout` | Booking CTA + Cal embed load | `step`, `content_id`, `slug` |
+| `AddPaymentInfo` | Cal embed payment step messages | `step` |
+| `Purchase` | Cal booking success, payment success flows | `value`, `currency`, `transaction_id`, `contents` |
+| `CompleteRegistration` | Assessment completion & signup flows | `session_id`, `question_count`, `email` |
+
+Results routes remain suppressed unless `allowOnResults` is passed via `sendQuoraEvent(..., { allowOnResults: true })`.
+
+## Consent & Debugging
+- Pixel initialises only when `window.__consent.analytics === true`.
+- Debug mode via `?qdebug=1` enables verbose console output and exposes `window.__QW_STATUS__()` plus `window.qpTest()`.
+- Helper auto-attaches `conversion_id` (UUID) and posts to `/functions/v1/quora-capi` for server dedupe when consent is granted.
+
+## Conversions API
+- Edge function expects `QUORA_TOKEN` (bearer token) and optional `QUORA_PIXEL_ID` env vars.
+- Request payload: `{ event_name, conversion_id, value?, currency?, email?, contents?, content_ids?, event_time?, client_ip?, user_agent? }`.
+- Email is normalised + SHA-256 hashed server-side via `_shared/crypto.ts`.
+- Retries (3x exponential backoff) on 429 / 5xx responses, returns `{ ok, status, eventId }`.
+- Pass consent using `x-consent-analytics: true` header; function returns 204 when analytics consent is denied.
+
+## CSP Allowlist
+Ensure the following origins are present in `script-src`, `img-src`, and `connect-src` as appropriate:
+- `https://a.quora.com`
+- `https://q.quora.com`
+
+## QA Checklist
+1. Load any page with `?qdebug=1` → console shows `[Quora] configured` once consent is granted.
+2. Navigate SPA routes → verify `ViewContent` beacons include accurate `page_path`.
+3. Start an assessment → `GenerateLead` fires with session metadata.
+4. Click a service `Book` CTA → `AddToCart` beacon contains `contents` payload.
+5. Open Cal booking flow → `InitiateCheckout` fired; proceed to payment step to see `AddPaymentInfo`.
+6. Complete a booking → `Purchase` beacon includes `value`, `currency`, `transaction_id`; check Supabase logs for matching `/functions/v1/quora-capi` 2xx response with shared `conversion_id`.
+7. Deny analytics consent → no Quora network activity.
+8. Results pages (`/results*`) emit only `ViewContent` unless `allowOnResults` override used.
+
+## Rollback
+1. Remove Quora scripts and helper block from `index.html`.
+2. Delete `src/lib/quora` utilities and references from analytics / route tracking / components.
+3. Remove Quora-related tests and docs, update `tests/run-tests.mjs`.
+4. Delete `supabase/functions/quora-capi` and `_shared/quoraCapi.ts` helpers.
+5. Revert CSP entries if they were added solely for Quora.
+

--- a/index.html
+++ b/index.html
@@ -400,6 +400,135 @@
       })();
     </script>
     <!-- End LinkedIn Insight Tag helpers -->
+    <!-- Quora Pixel Code (Base) -->
+    <script>
+!function(q,e,v,n,t,s){if(q.qp) return; n=q.qp=function(){n.qp?n.qp.apply(n,arguments):n.queue.push(arguments);}; n.queue=[];
+t=document.createElement(e);t.async=!0;t.src=v; s=document.getElementsByTagName(e)[0]; s.parentNode.insertBefore(t,s);
+}(window,'script','https://a.quora.com/qevents.js');
+    </script>
+    <noscript><img height="1" width="1" style="display:none"
+      src="https://q.quora.com/_/ad/3b47052b877e48a5b43d5f0d775d8e06/pixel?tag=ViewContent&noscript=1"/></noscript>
+    <!-- End of Quora Pixel Code -->
+    <script>
+      (function(){
+        const PIXEL_ID = '3b47052b877e48a5b43d5f0d775d8e06';
+        const RESULTS_RE = /\/results(\/|$)/i;
+        const ALLOW_RESULTS_FLAG = '__allowResults';
+        const DEBUG = /\bqdebug=1\b/.test(location.search);
+        let configured = false, lastError = null;
+
+        function hasAnalyticsConsent(){
+          try {
+            const c = window.__consent;
+            return !!(c && c.analytics === true);
+          } catch (e) { return false; }
+        }
+
+        function initQuora(email){
+          try {
+            if (configured || !window.qp) return;
+            if (email) { qp('init', PIXEL_ID, { email: email }); }
+            else { qp('init', PIXEL_ID); }
+            configured = true;
+            if (DEBUG) console.info('[Quora] configured', { email: !!email });
+          } catch (e) { lastError = e; if (DEBUG) console.warn('[Quora] init error', e); }
+        }
+
+        // Defer init until consent is granted
+        function tryConfigure(){
+          if (configured) return true;
+          if (!hasAnalyticsConsent() || typeof window.qp !== 'function') return false;
+          // Optionally pass known email for advanced matching (hashed by Quora)
+          const knownEmail = (window.__knownUser && window.__knownUser.email) || undefined;
+          initQuora(knownEmail);
+          return configured;
+        }
+
+        // Poll briefly; also listen for consent changes
+        let attempts = 0, timer = setInterval(function(){
+          attempts++; if (tryConfigure() || attempts > 40) clearInterval(timer);
+        }, 500);
+        ['consent:updated','app:consent:updated','consentchange'].forEach(evt=>{
+          addEventListener(evt, tryConfigure, { passive:true });
+        });
+
+        function uuid(){
+          if (crypto && crypto.randomUUID) return crypto.randomUUID();
+          return (Date.now().toString(36)+'-'+Math.random().toString(36).slice(2));
+        }
+
+        function invokeCapi(eventName, payload){
+          if (!payload || !payload.conversion_id || !hasAnalyticsConsent()) return;
+          const body = {
+            event_name: eventName,
+            conversion_id: payload.conversion_id,
+            value: typeof payload.value === 'number' ? payload.value : undefined,
+            currency: typeof payload.currency === 'string' ? payload.currency : undefined,
+            email: typeof payload.email === 'string' ? payload.email : undefined,
+            contents: Array.isArray(payload.contents) ? payload.contents : undefined,
+            content_ids: Array.isArray(payload.content_ids) ? payload.content_ids : undefined,
+            event_time: Math.floor(Date.now() / 1000),
+            user_agent: navigator.userAgent,
+          };
+          if (window.__knownUser && typeof window.__knownUser.email === 'string' && !body.email) {
+            body.email = window.__knownUser.email;
+          }
+          const requestInit = {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'x-consent-analytics': hasAnalyticsConsent() ? 'true' : 'false',
+            },
+            body: JSON.stringify(body),
+            keepalive: true,
+          };
+          try {
+            const invoke = window.__supabaseFunctionFetch;
+            if (typeof invoke === 'function') {
+              invoke('quora-capi', requestInit).catch(() => {});
+            } else {
+              fetch('/functions/v1/quora-capi', requestInit).catch(() => {});
+            }
+          } catch (err) {
+            if (DEBUG) console.warn('[Quora] CAPI error', err);
+          }
+        }
+
+        window.qpTrack = function(eventName, props){
+          if (!configured) { if (DEBUG) console.info('[Quora] drop (not configured)', eventName); return; }
+          const payload = Object.assign({}, props || {});
+          const allowOnResults = !!payload[ALLOW_RESULTS_FLAG];
+          if (ALLOW_RESULTS_FLAG in payload) delete payload[ALLOW_RESULTS_FLAG];
+
+          if (RESULTS_RE.test(location.pathname) && eventName !== 'ViewContent' && !allowOnResults){
+            if (DEBUG) console.info('[Quora] suppressed on /results', eventName);
+            return;
+          }
+          if (!payload.conversion_id) payload.conversion_id = uuid();
+          try {
+            qp('track', eventName, payload);
+            if (payload.conversion_id) {
+              try { window.__lastQuoraConversionId = payload.conversion_id; } catch (_) {}
+            }
+            invokeCapi(eventName, payload);
+            if (DEBUG) console.info('[Quora] track', eventName, payload);
+            return payload.conversion_id;
+          } catch (e) { lastError = e; if (DEBUG) console.warn('[Quora] track error', e); }
+        };
+
+        // Debug helpers
+        window.__QW_STATUS__ = function(){
+          return {
+            configured, hasTwqLike:false, // placeholder parity
+            consent: hasAnalyticsConsent(),
+            path: location.pathname, lastError
+          };
+        };
+        window.qpTest = function(){
+          return window.qpTrack('GenerateLead', { test:true });
+        };
+      })();
+    </script>
     <!-- Reddit Pixel (init) -->
     <script>
       !function(w,d){if(!w.rdt){var p=w.rdt=function(){p.sendEvent?p.sendEvent.apply(p,arguments):p.callQueue.push(arguments)};p.callQueue=[];

--- a/src/components/CalEmbed.tsx
+++ b/src/components/CalEmbed.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from "react";
+import { sendQuoraEvent } from "@/lib/quora/events";
 import { trackEvent } from "@/utils/analytics";
 
 interface CalEmbedProps {
@@ -8,9 +9,24 @@ interface CalEmbedProps {
 const CalEmbed = ({ slug }: CalEmbedProps) => {
   useEffect(() => {
     trackEvent("booking_page_view", { slug });
+    sendQuoraEvent("InitiateCheckout", { step: "cal.com_embed", slug });
     const handler = (event: MessageEvent) => {
       if (event.origin !== "https://cal.com") return;
       trackEvent("booking_event", { slug, data: event.data });
+      const normalized = normalizeCalMessage(event.data);
+      if (normalized?.type === "booking_success") {
+        sendQuoraEvent("Purchase", {
+          value: normalized.value,
+          currency: normalized.currency,
+          transaction_id: normalized.bookingId,
+          contents: normalized.contents,
+        });
+      }
+      if (normalized?.type === "payment_info") {
+        sendQuoraEvent("AddPaymentInfo", {
+          step: normalized.step || "cal.com_payment",
+        });
+      }
     };
     window.addEventListener("message", handler);
     return () => window.removeEventListener("message", handler);
@@ -27,3 +43,113 @@ const CalEmbed = ({ slug }: CalEmbedProps) => {
 };
 
 export default CalEmbed;
+
+type NormalizedCalMessage = {
+  type?: "booking_success" | "payment_info";
+  value?: number;
+  currency?: string;
+  bookingId?: string;
+  step?: string;
+  contents?: Array<Record<string, unknown>>;
+};
+
+function tryParseJson(value: unknown): unknown {
+  if (typeof value !== "string") return value;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}
+
+function coerceNumber(candidate: unknown): number | undefined {
+  if (typeof candidate === "number" && Number.isFinite(candidate)) return candidate;
+  if (typeof candidate === "string") {
+    const parsed = Number(candidate.replace(/[^0-9.]/g, ""));
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return undefined;
+}
+
+function normalizeCalMessage(raw: unknown): NormalizedCalMessage | undefined {
+  const data = tryParseJson(raw);
+  if (!data || typeof data !== "object") return undefined;
+
+  const eventName = extractString(
+    (data as Record<string, unknown>).event ||
+      (data as Record<string, unknown>).eventName ||
+      (data as Record<string, unknown>).type ||
+      (data as Record<string, unknown>).action,
+  );
+  const lowered = eventName?.toLowerCase() || "";
+
+  const detail = selectFirstObject([
+    (data as Record<string, unknown>).payload,
+    (data as Record<string, unknown>).data,
+    (data as Record<string, unknown>).detail,
+  ]);
+
+  const booking = selectFirstObject([
+    detail?.booking,
+    detail?.event,
+    detail,
+  ]);
+
+  const value = coerceNumber(
+    detail?.price ||
+      detail?.amount ||
+      detail?.payment?.amount ||
+      booking?.price ||
+      booking?.amount ||
+      booking?.payment?.amount,
+  );
+  const currency = extractString(
+    detail?.currency || booking?.currency || detail?.payment?.currency,
+  );
+  const bookingId = extractString(
+    detail?.bookingId || detail?.id || booking?.id || (data as Record<string, unknown>).eventId,
+  );
+
+  if (lowered.includes("booking") && (lowered.includes("success") || lowered.includes("confirmed"))) {
+    const contents = booking?.service
+      ? [
+          {
+            content_id: extractString(booking.service.id),
+            content_name: extractString(booking.service.name),
+            content_price: value,
+            num_items: 1,
+          },
+        ]
+      : undefined;
+    return {
+      type: "booking_success",
+      value,
+      currency,
+      bookingId,
+      contents,
+    };
+  }
+
+  if (lowered.includes("payment")) {
+    return {
+      type: "payment_info",
+      step: eventName || "payment",
+    };
+  }
+
+  return undefined;
+}
+
+function extractString(input: unknown): string | undefined {
+  if (typeof input === "string" && input.trim().length > 0) return input.trim();
+  return undefined;
+}
+
+function selectFirstObject(inputs: Array<unknown>): Record<string, any> | undefined {
+  for (const candidate of inputs) {
+    if (candidate && typeof candidate === "object") {
+      return candidate as Record<string, any>;
+    }
+  }
+  return undefined;
+}

--- a/src/components/ServiceCard.tsx
+++ b/src/components/ServiceCard.tsx
@@ -6,6 +6,7 @@ import {
   buildFacebookPayloadFromService,
   rememberFacebookDpaPayload,
 } from "@/lib/facebook";
+import { sendQuoraEvent } from "@/lib/quora/events";
 
 export function ServiceCard({
   service,
@@ -23,6 +24,22 @@ export function ServiceCard({
     if (typeof window !== "undefined" && window.fbTrack) {
       window.fbTrack("AddToCart", payload);
     }
+    const numericPrice = Number(service.price.replace(/[^0-9.]/g, ""));
+    const value = Number.isFinite(numericPrice) ? numericPrice : undefined;
+    sendQuoraEvent("AddToCart", {
+      value,
+      currency: value ? "USD" : undefined,
+      contents: [
+        {
+          content_id: service.id,
+          content_name: service.title,
+          content_price: value,
+          num_items: 1,
+        },
+      ],
+      content_ids: [service.id],
+    });
+    sendQuoraEvent("InitiateCheckout", { step: "cal.com_open", content_id: service.id });
     const el = document.getElementById("book");
     if (el) el.scrollIntoView({ behavior: "smooth", block: "start" });
   };

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,5 +1,6 @@
 // Google Analytics tracking utility
 import { IS_PREVIEW } from './env';
+import { sendQuoraEvent } from './quora/events';
 import { sendTwitterEvent } from './twitter/events';
 import {
   buildFacebookDpaPayload,
@@ -54,6 +55,10 @@ export const trackLead = (email?: string, metadata: Record<string, any> = {}) =>
       ...metadata,
       email_address: email,
     });
+    sendQuoraEvent('GenerateLead', {
+      email: email || undefined,
+      ...metadata,
+    });
   }
 };
 
@@ -71,6 +76,10 @@ export const trackAssessmentStart = (sessionId: string) => {
   }
 
   sendTwitterEvent('Lead', {
+    content_name: 'PRISM Assessment',
+    session_id: sessionId,
+  });
+  sendQuoraEvent('GenerateLead', {
     content_name: 'PRISM Assessment',
     session_id: sessionId,
   });
@@ -112,6 +121,10 @@ export const trackAssessmentComplete = (sessionId: string, totalQuestions: numbe
     session_id: sessionId,
     question_count: totalQuestions,
   });
+  sendQuoraEvent('CompleteRegistration', {
+    session_id: sessionId,
+    question_count: totalQuestions,
+  });
 
   // Fire app event that other trackers can listen to
   if (typeof window !== 'undefined') {
@@ -141,6 +154,10 @@ export const trackAccountCreation = (email: string, sessionId?: string) => {
     source: 'assessment',
     session_id: sessionId,
   });
+  sendQuoraEvent('CompleteRegistration', {
+    email,
+    session_id: sessionId,
+  });
 
   // Fire app event that other trackers can listen to
   if (typeof window !== 'undefined') {
@@ -165,6 +182,15 @@ export const trackResultsViewed = (sessionId: string, typeCode?: string) => {
 
   sendTwitterEvent(
     'ContentView',
+    {
+      content_name: 'PRISM Results',
+      session_id: sessionId,
+      type_code: typeCode,
+    },
+    { allowOnResults: true },
+  );
+  sendQuoraEvent(
+    'ViewContent',
     {
       content_name: 'PRISM Results',
       session_id: sessionId,
@@ -208,6 +234,12 @@ export const trackPaymentSuccess = (
   }
 
   sendTwitterEvent('Purchase', {
+    value,
+    currency,
+    transaction_id: transactionId,
+    session_id: sessionId,
+  });
+  sendQuoraEvent('Purchase', {
     value,
     currency,
     transaction_id: transactionId,

--- a/src/lib/quora/events.ts
+++ b/src/lib/quora/events.ts
@@ -1,0 +1,41 @@
+declare global {
+  interface Window {
+    qpTrack?: (event: string, props?: Record<string, unknown>) => string | undefined;
+    __lastQuoraConversionId?: string;
+  }
+}
+
+export type QuoraPayload = {
+  value?: number;
+  currency?: string;
+  email?: string;
+  content_ids?: string[];
+  contents?: Array<Record<string, unknown>>;
+  conversion_id?: string;
+  [key: string]: unknown;
+};
+
+export function sendQuoraEvent(
+  event: string,
+  props: QuoraPayload = {},
+  { allowOnResults = false }: { allowOnResults?: boolean } = {}
+): string | undefined {
+  if (typeof window === 'undefined' || typeof window.qpTrack !== 'function') return undefined;
+  const payload: QuoraPayload = { ...props };
+  if (allowOnResults) {
+    (payload as Record<string, unknown>).__allowResults = true;
+  }
+  const conversionId = window.qpTrack(event, payload);
+  if (conversionId) {
+    window.__lastQuoraConversionId = conversionId;
+  }
+  return conversionId;
+}
+
+export function sendQuoraPageView(path?: string) {
+  const props: QuoraPayload = {};
+  if (path) {
+    (props as Record<string, unknown>).page_path = path;
+  }
+  sendQuoraEvent('ViewContent', props);
+}

--- a/src/lib/route-tracking.ts
+++ b/src/lib/route-tracking.ts
@@ -1,5 +1,6 @@
 // SPA route change tracking for Reddit and other analytics platforms
 
+import { sendQuoraEvent, sendQuoraPageView } from './quora/events';
 import { sendTwitterEvent, sendTwitterPageView } from './twitter/events';
 
 // Track route changes for SPA navigation
@@ -19,6 +20,7 @@ export const trackRouteChange = (path: string) => {
   }
 
   sendTwitterPageView(path);
+  sendQuoraPageView(path);
 
   if (debug) {
     console.info('[Twitter Pixel] PageView fired', { path });
@@ -30,6 +32,8 @@ export const trackRouteChange = (path: string) => {
       page_path: path
     });
   }
+
+  trackRouteSpecificEvents(path);
 };
 
 // Set up SPA route tracking listeners
@@ -63,7 +67,7 @@ export const initializeRouteTracking = () => {
 };
 
 // Route-specific event tracking
-export const trackRouteSpecificEvents = (path: string) => {
+export function trackRouteSpecificEvents(path: string) {
   if (typeof window === 'undefined') return;
 
   const normalizedPath = path.toLowerCase();
@@ -77,6 +81,7 @@ export const trackRouteSpecificEvents = (path: string) => {
       window.fbTrack('ViewContent', { content_name: 'Assessment' });
     }
     sendTwitterEvent('ContentView', { content_name: 'Assessment' });
+    sendQuoraEvent('GenerateLead', { content_name: 'Assessment' });
   }
 
   // Results page tracking
@@ -89,6 +94,11 @@ export const trackRouteSpecificEvents = (path: string) => {
     }
     sendTwitterEvent(
       'ContentView',
+      { content_name: 'PRISM Results' },
+      { allowOnResults: true },
+    );
+    sendQuoraEvent(
+      'ViewContent',
       { content_name: 'PRISM Results' },
       { allowOnResults: true },
     );
@@ -107,5 +117,6 @@ export const trackRouteSpecificEvents = (path: string) => {
       window.fbTrack('CompleteRegistration');
     }
     sendTwitterEvent('SignUp', {});
+    sendQuoraEvent('CompleteRegistration', {});
   }
-};
+}

--- a/supabase/functions/_shared/quoraCapi.ts
+++ b/supabase/functions/_shared/quoraCapi.ts
@@ -1,0 +1,85 @@
+export interface BuildQuoraPayloadInput {
+  pixelId: string;
+  eventName: string;
+  eventTime: number;
+  conversionId?: string;
+  value?: number;
+  currency?: string;
+  contents?: Array<Record<string, unknown>>;
+  contentIds?: string[];
+  hashedEmail?: string;
+  clientIp?: string;
+  userAgent?: string;
+}
+
+export interface QuoraRequestEvent {
+  event_name: string;
+  event_time: number;
+  action_source: 'website';
+  conversion_id?: string;
+  user_data?: Record<string, unknown>;
+  custom_data?: Record<string, unknown>;
+  content_ids?: string[];
+}
+
+export interface QuoraRequestBody {
+  pixel_id: string;
+  data: QuoraRequestEvent[];
+}
+
+export function buildQuoraRequestBody(input: BuildQuoraPayloadInput): QuoraRequestBody {
+  const userData: Record<string, unknown> = {};
+  if (input.hashedEmail) {
+    userData.email = input.hashedEmail;
+  }
+  if (input.clientIp) {
+    userData.client_ip_address = input.clientIp;
+  }
+  if (input.userAgent) {
+    userData.client_user_agent = input.userAgent;
+  }
+
+  const customData: Record<string, unknown> = {};
+  if (typeof input.value === 'number' && Number.isFinite(input.value)) {
+    customData.value = input.value;
+  }
+  if (typeof input.currency === 'string' && input.currency.trim()) {
+    customData.currency = input.currency.trim();
+  }
+  if (Array.isArray(input.contents) && input.contents.length > 0) {
+    customData.contents = input.contents;
+  }
+  if (Array.isArray(input.contentIds) && input.contentIds.length > 0) {
+    customData.content_ids = input.contentIds;
+  }
+
+  const event: QuoraRequestEvent = {
+    event_name: input.eventName,
+    event_time: input.eventTime,
+    action_source: 'website',
+  };
+
+  if (input.conversionId) {
+    event.conversion_id = input.conversionId;
+  }
+  if (Object.keys(userData).length > 0) {
+    event.user_data = userData;
+  }
+  if (Object.keys(customData).length > 0) {
+    event.custom_data = customData;
+  }
+  if (Array.isArray(input.contentIds) && input.contentIds.length > 0) {
+    event.content_ids = input.contentIds;
+  }
+
+  return {
+    pixel_id: input.pixelId,
+    data: [event],
+  };
+}
+
+export function shouldRetry(status: number): boolean {
+  if (status === 429) return true;
+  if (status >= 500) return true;
+  return false;
+}

--- a/supabase/functions/quora-capi/index.ts
+++ b/supabase/functions/quora-capi/index.ts
@@ -1,0 +1,286 @@
+import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+import { sha256HexLower } from "../_shared/crypto.ts";
+import {
+  buildQuoraRequestBody,
+  shouldRetry,
+  type BuildQuoraPayloadInput,
+  type QuoraRequestBody,
+} from "../_shared/quoraCapi.ts";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers":
+    "authorization, x-client-info, apikey, content-type, x-consent-analytics",
+  "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+  "Cache-Control": "no-store",
+};
+
+const PIXEL_ID = Deno.env.get("QUORA_PIXEL_ID") ?? "3b47052b877e48a5b43d5f0d775d8e06";
+const QUORA_ENDPOINT = "https://q.quora.com/conversion_api/event";
+const MAX_ATTEMPTS = 3;
+const BASE_RETRY_DELAY_MS = 250;
+
+interface IncomingPayload {
+  event_name?: unknown;
+  event_time?: unknown;
+  conversion_id?: unknown;
+  value?: unknown;
+  currency?: unknown;
+  email?: unknown;
+  contents?: unknown;
+  content_ids?: unknown;
+  client_ip?: unknown;
+  user_agent?: unknown;
+  consentAnalytics?: unknown;
+}
+
+type JsonObject = Record<string, unknown>;
+
+type ConsentFlag = boolean | undefined;
+
+type FetchLike = typeof fetch;
+
+function parseBoolean(input: unknown): ConsentFlag {
+  if (typeof input === "boolean") return input;
+  if (typeof input === "string") {
+    const lowered = input.trim().toLowerCase();
+    if (lowered === "true") return true;
+    if (lowered === "false") return false;
+  }
+  return undefined;
+}
+
+function parseString(input: unknown): string | undefined {
+  if (typeof input === "string" && input.trim().length > 0) return input.trim();
+  return undefined;
+}
+
+function parseNumber(input: unknown): number | undefined {
+  if (typeof input === "number" && Number.isFinite(input)) return input;
+  if (typeof input === "string" && input.trim().length > 0) {
+    const parsed = Number(input);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return undefined;
+}
+
+function parseContents(input: unknown): Array<Record<string, unknown>> | undefined {
+  if (!Array.isArray(input)) return undefined;
+  const filtered = input.filter((item) => item && typeof item === "object") as Array<
+    Record<string, unknown>
+  >;
+  return filtered.length > 0 ? filtered : undefined;
+}
+
+function parseStringArray(input: unknown): string[] | undefined {
+  if (!Array.isArray(input)) return undefined;
+  const filtered = input
+    .map((value) => parseString(value))
+    .filter((value): value is string => typeof value === "string");
+  return filtered.length > 0 ? filtered : undefined;
+}
+
+function bestEffortIp(req: Request, provided?: unknown): string | undefined {
+  const direct = parseString(provided);
+  if (direct) return direct;
+  const forwarded = req.headers.get("x-forwarded-for");
+  if (!forwarded) return undefined;
+  const first = forwarded.split(",")[0]?.trim();
+  return first && first.length > 0 ? first : undefined;
+}
+
+function bestEffortUserAgent(req: Request, provided?: unknown): string | undefined {
+  const direct = parseString(provided);
+  if (direct) return direct;
+  const fromHeader = req.headers.get("user-agent");
+  return fromHeader?.trim() || undefined;
+}
+
+function parseEventTime(input: unknown): number | undefined {
+  const parsed = parseNumber(input);
+  if (!parsed) return undefined;
+  const rounded = Math.floor(parsed);
+  return Number.isFinite(rounded) ? rounded : undefined;
+}
+
+async function ensureHashedEmail(input: unknown): Promise<string | undefined> {
+  const value = parseString(input);
+  if (!value) return undefined;
+  const lowered = value.toLowerCase();
+  if (/^[0-9a-f]{64}$/.test(lowered)) {
+    return lowered;
+  }
+  return sha256HexLower(lowered);
+}
+
+async function postWithRetry(
+  fetchImpl: FetchLike,
+  token: string,
+  body: QuoraRequestBody,
+): Promise<{ response?: Response; error?: unknown }> {
+  const serializedBody = JSON.stringify(body);
+  let attempt = 0;
+  let lastError: unknown;
+  while (attempt < MAX_ATTEMPTS) {
+    attempt += 1;
+    try {
+      const response = await fetchImpl(QUORA_ENDPOINT, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: serializedBody,
+      });
+      if (response.ok || !shouldRetry(response.status) || attempt === MAX_ATTEMPTS) {
+        return { response };
+      }
+      await wait(BASE_RETRY_DELAY_MS * 2 ** (attempt - 1));
+      continue;
+    } catch (error) {
+      lastError = error;
+      if (attempt === MAX_ATTEMPTS) {
+        return { error: lastError };
+      }
+      await wait(BASE_RETRY_DELAY_MS * 2 ** (attempt - 1));
+    }
+  }
+  return { error: lastError };
+}
+
+async function wait(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function okResponse(payload: JsonObject, status = 200): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "Content-Type": "application/json", ...corsHeaders },
+  });
+}
+
+function errorResponse(payload: JsonObject, status = 500): Response {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "Content-Type": "application/json", ...corsHeaders },
+  });
+}
+
+function consentFromHeader(req: Request): ConsentFlag {
+  const headerValue = req.headers.get("x-consent-analytics");
+  return parseBoolean(headerValue || undefined);
+}
+
+async function readJsonSafe<T>(req: Request): Promise<T | undefined> {
+  try {
+    return (await req.json()) as T;
+  } catch {
+    return undefined;
+  }
+}
+
+function resolveEnvironment(): "prod" | "dev" {
+  const raw = (Deno.env.get("SUPABASE_ENV") || Deno.env.get("ENVIRONMENT") || "").toLowerCase();
+  if (raw.startsWith("prod")) return "prod";
+  return "dev";
+}
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  const token = Deno.env.get("QUORA_TOKEN");
+  if (!token) {
+    return errorResponse({ ok: false, code: "missing_token" }, 500);
+  }
+
+  const url = new URL(req.url);
+  if (req.method === "GET" && url.searchParams.get("status") === "1") {
+    return okResponse({ ok: true, hasToken: true, pixelId: PIXEL_ID, env: resolveEnvironment() });
+  }
+
+  if (req.method !== "POST") {
+    return errorResponse({ ok: false, code: "method_not_allowed" }, 405);
+  }
+
+  const rawBody = await readJsonSafe<IncomingPayload>(req);
+  if (!rawBody) {
+    return errorResponse({ ok: false, code: "invalid_json" }, 400);
+  }
+
+  const consentHeader = consentFromHeader(req);
+  const consentBody = parseBoolean(rawBody.consentAnalytics);
+  const consent = consentBody ?? consentHeader;
+  if (consent === false) {
+    return new Response(null, { status: 204, headers: corsHeaders });
+  }
+
+  const eventName = parseString(rawBody.event_name);
+  if (!eventName) {
+    return errorResponse({ ok: false, code: "missing_event_name" }, 400);
+  }
+
+  const conversionId = parseString(rawBody.conversion_id);
+  if (!conversionId) {
+    return errorResponse({ ok: false, code: "missing_conversion_id" }, 400);
+  }
+
+  const eventTime = parseEventTime(rawBody.event_time) ?? Math.floor(Date.now() / 1000);
+  const value = parseNumber(rawBody.value);
+  const currency = parseString(rawBody.currency);
+  const contents = parseContents(rawBody.contents);
+  const contentIds = parseStringArray(rawBody.content_ids);
+  const clientIp = bestEffortIp(req, rawBody.client_ip);
+  const userAgent = bestEffortUserAgent(req, rawBody.user_agent);
+  const hashedEmail = await ensureHashedEmail(rawBody.email);
+
+  const buildInput: BuildQuoraPayloadInput = {
+    pixelId: PIXEL_ID,
+    eventName,
+    eventTime,
+    conversionId,
+    value,
+    currency,
+    contents,
+    contentIds,
+    hashedEmail,
+    clientIp,
+    userAgent,
+  };
+
+  const body = buildQuoraRequestBody(buildInput);
+  const { response, error } = await postWithRetry(fetch, token, body);
+  if (error) {
+    return errorResponse({ ok: false, code: "network_error" }, 502);
+  }
+  if (!response) {
+    return errorResponse({ ok: false, code: "unknown_error" }, 500);
+  }
+
+  const responseBody = await safeReadResponse(response);
+
+  if (!response.ok) {
+    return errorResponse(
+      {
+        ok: false,
+        code: "quora_error",
+        status: response.status,
+        body: responseBody,
+      },
+      response.status,
+    );
+  }
+
+  return okResponse({ ok: true, status: response.status, eventId: conversionId, body: responseBody });
+});
+
+async function safeReadResponse(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (!text) return undefined;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}

--- a/tests/quoraCapiPayload.test.ts
+++ b/tests/quoraCapiPayload.test.ts
@@ -1,0 +1,66 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+void test("buildQuoraRequestBody maps identifiers and custom data", async () => {
+  const { buildQuoraRequestBody } = await import("../supabase/functions/_shared/quoraCapi.ts");
+
+  const body = buildQuoraRequestBody({
+    pixelId: "pixel-1",
+    eventName: "Purchase",
+    eventTime: 123456,
+    conversionId: "conv-1",
+    value: 99.5,
+    currency: "USD",
+    contents: [{ content_id: "sku-1", quantity: 1 }],
+    contentIds: ["sku-1"],
+    hashedEmail: "abc123",
+    clientIp: "203.0.113.42",
+    userAgent: "test-agent",
+  });
+
+  assert.equal(body.pixel_id, "pixel-1");
+  assert.equal(body.data.length, 1);
+  const event = body.data[0];
+  assert.equal(event.event_name, "Purchase");
+  assert.equal(event.event_time, 123456);
+  assert.equal(event.conversion_id, "conv-1");
+  assert.deepEqual(event.content_ids, ["sku-1"]);
+  assert.deepEqual(event.user_data, {
+    email: "abc123",
+    client_ip_address: "203.0.113.42",
+    client_user_agent: "test-agent",
+  });
+  assert.deepEqual(event.custom_data, {
+    value: 99.5,
+    currency: "USD",
+    contents: [{ content_id: "sku-1", quantity: 1 }],
+    content_ids: ["sku-1"],
+  });
+});
+
+void test("buildQuoraRequestBody omits optional sections when absent", async () => {
+  const { buildQuoraRequestBody } = await import("../supabase/functions/_shared/quoraCapi.ts");
+
+  const body = buildQuoraRequestBody({
+    pixelId: "pixel-2",
+    eventName: "Lead",
+    eventTime: 42,
+  });
+
+  const event = body.data[0];
+  assert.equal(event.event_name, "Lead");
+  assert.equal(event.action_source, "website");
+  assert.equal(event.custom_data, undefined);
+  assert.equal(event.user_data, undefined);
+  assert.equal(event.conversion_id, undefined);
+});
+
+void test("shouldRetry matches retryable statuses", async () => {
+  const { shouldRetry } = await import("../supabase/functions/_shared/quoraCapi.ts");
+
+  assert.equal(shouldRetry(429), true);
+  assert.equal(shouldRetry(500), true);
+  assert.equal(shouldRetry(503), true);
+  assert.equal(shouldRetry(499), false);
+  assert.equal(shouldRetry(200), false);
+});

--- a/tests/quoraEvents.test.ts
+++ b/tests/quoraEvents.test.ts
@@ -1,0 +1,68 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+void test("sendQuoraEvent returns undefined when window missing", async (t) => {
+  const originalWindow = (globalThis as any).window;
+  delete (globalThis as any).window;
+
+  t.after(() => {
+    if (originalWindow) {
+      (globalThis as any).window = originalWindow;
+    } else {
+      delete (globalThis as any).window;
+    }
+  });
+
+  const module = await import("../src/lib/quora/events.ts");
+  assert.equal(module.sendQuoraEvent("GenerateLead"), undefined);
+});
+
+void test("sendQuoraEvent forwards payload and captures conversion id", async (t) => {
+  const calls: Array<{ event: string; payload: Record<string, unknown> }> = [];
+  (globalThis as any).window = {
+    qpTrack(event: string, payload: Record<string, unknown>) {
+      calls.push({ event, payload });
+      return "conv-123";
+    },
+  };
+
+  t.after(() => {
+    delete (globalThis as any).window;
+  });
+
+  const { sendQuoraEvent } = await import("../src/lib/quora/events.ts");
+  const returned = sendQuoraEvent(
+    "Purchase",
+    { value: 42, currency: "USD" },
+    { allowOnResults: true },
+  );
+
+  assert.equal(returned, "conv-123");
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].event, "Purchase");
+  assert.equal(calls[0].payload.value, 42);
+  assert.equal(calls[0].payload.currency, "USD");
+  assert.equal(calls[0].payload.__allowResults, true);
+  assert.equal((globalThis as any).window.__lastQuoraConversionId, "conv-123");
+});
+
+void test("sendQuoraPageView attaches page_path when provided", async (t) => {
+  const calls: Array<{ event: string; payload: Record<string, unknown> }> = [];
+  (globalThis as any).window = {
+    qpTrack(event: string, payload: Record<string, unknown>) {
+      calls.push({ event, payload });
+      return "conv-pv";
+    },
+  };
+
+  t.after(() => {
+    delete (globalThis as any).window;
+  });
+
+  const { sendQuoraPageView } = await import("../src/lib/quora/events.ts");
+  sendQuoraPageView("/test/path");
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].event, "ViewContent");
+  assert.equal(calls[0].payload.page_path, "/test/path");
+});

--- a/tests/run-tests.mjs
+++ b/tests/run-tests.mjs
@@ -28,6 +28,8 @@ const TEST_FILES = [
   'tests/tiktokClient.test.ts',
   'tests/linkedinCapiPayload.test.ts',
   'tests/linkedinTrack.test.ts',
+  'tests/quoraCapiPayload.test.ts',
+  'tests/quoraEvents.test.ts',
   'tests/getUserJwt.test.ts',
   'tests/classifyRpcError.test.ts',
   'tests/saveResponseIdempotent.test.ts',


### PR DESCRIPTION
## Summary
- add a consent-aware Quora Pixel loader with qpTrack helper, debug hooks, and automatic CAPI fan-out
- wire Quora SPA page views and business events across routing, analytics, booking CTA, and Cal embed flows
- implement Supabase quora-capi edge function, shared payload builder, documentation, env vars, and regression tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf2e68ac70832abbbb72b4d24ad5a9