### PR TITLE
Audit and repair SPA analytics across vendors

### DIFF
--- a/docs/tracking-audit.md
+++ b/docs/tracking-audit.md
@@ -1,0 +1,112 @@
+# SPA Tracking Audit — Quora, Twitter/X, LinkedIn, Facebook, Reddit, GA4
+
+## Summary Table
+
+| Vendor      | Loader Detected | Helper/Wrapper | SPA Page View | Business Events | Fixes & Notes |
+|-------------|-----------------|----------------|---------------|-----------------|---------------|
+| Quora       | ✓ `https://a.quora.com/qevents.js` | ✓ `qpTrack` consent-gated helper | ✓ via `trackRouteChange` | GenerateLead, AddToCart, Purchase, CompleteRegistration, Results guarded | Added config-aware lead mirroring + SPA router integration; debug hooks `?qdebug=1`, `__QW_STATUS__()`, `qpTest()` validated |
+| Twitter/X   | ✓ `https://static.ads-twitter.com/uwt.js` | ✓ `twqTrack` consent guard + results gate | ✓ via `sendTwitterPageView` | Lead, AddToCart, Purchase, SignUp, Results guarded | Confirmed debug hooks `?twdebug=1`, `__twStatus()`, `twqTest()`; SPA route + event mapping repaired |
+| LinkedIn    | ✓ `https://snap.licdn.com/li.lms-analytics/insight.min.js` | ✓ Config-driven helpers (`sendLinkedIn*`) | ✓ Site Page View via config + consent | Lead, Signup, Purchase, AddToCart (config opt-in) | Added conversion ID config keys + client/server bridge; CAPI guard respects consent |
+| Facebook    | ✓ `https://connect.facebook.net/en_US/fbevents.js` | ✓ `fbTrack` helper | ✓ via route tracker | Lead, CompleteRegistration, Purchase, AddToCart | Route tracker mirrors key events; DPA payload preserved |
+| Reddit      | ✓ `https://www.redditstatic.com/ads/pixel.js` | ✓ `rdtTrack` wrapper + CAPI bridge | ✓ via route tracker | PageVisit, Lead, SignUp, AddToCart | SPA router unified; honours consent before client pixel |
+| GA4         | ✓ `gtag` + `G-J2XXMC9VWV` | N/A | ✓ `gtag('config', …)` | Page view, generate_lead, sign_up | Added route-driven page_path + milestone events |
+
+Console summary printed once per load (see `logAnalyticsSummary`) to confirm status.
+
+## Key Fixes Applied
+
+1. **LinkedIn**
+   - Introduced config-aware helpers (`sendLinkedInLead`, `sendLinkedInSignupEvent`, `sendLinkedInPurchase`, `sendLinkedInAddToCart`, `sendLinkedInPageView`).
+   - Added consent gate + optional client pixel firing with shared conversion IDs.
+   - Enabled SPA route tracking for Site Page View events.
+
+2. **Route Tracking**
+   - Centralised consent detection and SPA page view propagation for all vendors.
+   - Added business event mirroring (Lead, SignUp) aligned with guard requirements (no heavy events on `/results*`).
+   - Console audit table emitted for quick verification.
+
+3. **Business Events**
+   - Updated analytics helpers to broadcast LinkedIn events alongside Quora/Twitter/Facebook/Reddit.
+   - Extended booking CTA (`ServiceCard`) to send AddToCart events to Twitter, LinkedIn, Reddit, Quora, Facebook.
+
+4. **Configuration**
+   - `index.html` defaults include LinkedIn conversion ID keys (override via `window.__APP_CONFIG__`).
+   - Removed legacy LinkedIn route watcher to prevent duplicate events.
+
+5. **Documentation & QA**
+   - Added this audit report with QA checklist, CSP domains, debug references, and rollback guidance.
+
+## QA Checklist
+
+1. **Consent Gate**
+   - With consent denied (`window.__consent.analytics = false`), trigger SPA navigation and CTA clicks → no pixel network calls.
+   - Grant consent (`window.__consent.analytics = true`) and repeat → all vendors fire according to table.
+
+2. **Page Views**
+   - Load any route → Network tab should show requests:
+     - Quora `q.quora.com/_/ad/...`
+     - Twitter `i/adsct`, `t.co/i/adsct`
+     - LinkedIn `px.ads.linkedin.com/collect`
+     - Facebook `/tr?`
+     - Reddit `events.reddit.com`
+     - GA4 `/g/collect`
+
+3. **SPA Navigation**
+   - Navigate between SPA routes (`/`, `/assessment`, `/pricing`, etc.). Observe console table once and confirm each navigation emits page view events per vendor.
+
+4. **Business Events**
+   - Assessment start (`/assessment`) → Lead events recorded across Quora/Twitter/Facebook/Reddit/LinkedIn/GA4.
+   - Click “Book” CTA on pricing cards → AddToCart events for all vendors, LinkedIn helper resolves conversion ID via config.
+   - Complete assessment → CompleteRegistration/SignUp events for Quora/Twitter/Facebook/LinkedIn/Reddit; GA4 custom event.
+   - Successful purchase flow → Purchase events include `value` + `currency`, LinkedIn CAPI logs 2xx with `requestId`.
+   - Results route (`/results*`) → only page views fire; heavy conversions remain suppressed unless `__allowResults` is set.
+
+5. **Debug Hooks**
+   - `?qdebug=1` → console emits Quora diagnostics, `__QW_STATUS__()` & `qpTest()` return payload.
+   - `?twdebug=1` → console logs Twitter debug, `__twStatus()` & `twqTest()` available.
+   - `window.liTest('<conversion>', '[email protected]')` exercises LinkedIn CAPI smoke.
+
+6. **LinkedIn Config Validation**
+   - Ensure `window.__APP_CONFIG__` defines:
+     - `LINKEDIN_SITE_PAGE_VIEW_ID`
+     - `LINKEDIN_LEAD_CONVERSION_ID`
+     - `LINKEDIN_SIGNUP_CONVERSION_ID`
+     - `LINKEDIN_PURCHASE_CONVERSION_ID`
+     - `LINKEDIN_ADD_TO_CART_CONVERSION_ID`
+   - Defaults are `null`; override via deployment environment or inline config before boot.
+
+## CSP Requirements
+
+Ensure server CSP allowlists include the following for `script-src`, `img-src`, and `connect-src` as appropriate:
+
+- `a.quora.com`
+- `q.quora.com`
+- `static.ads-twitter.com`
+- `t.co`
+- `analytics.twitter.com`
+- `snap.licdn.com`
+- `px.ads.linkedin.com`
+- `connect.facebook.net`
+- `www.facebook.com`
+- `www.redditstatic.com`
+- `events.reddit.com`
+- `www.google-analytics.com`
+
+## Consent & Results Guarding
+
+- All helper wrappers short-circuit when `window.__consent.analytics !== true`.
+- `/results*` routes fire page views only; additional conversions require explicit `__allowResults` flag.
+
+## Debug Flags
+
+- Quora: `?qdebug=1`, functions `__QW_STATUS__()`, `qpTest()`.
+- Twitter/X: `?twdebug=1`, functions `__twStatus()`, `twqTest()`.
+- LinkedIn: `window.liTest(conversionId, email)` for CAPI smoke; console table summarises vendor status on load.
+
+## Rollback Plan
+
+1. Revert commits touching analytics via `git revert <commit>` or `git checkout HEAD^ -- index.html src/lib ...`.
+2. Remove LinkedIn config keys from `index.html` if not required.
+3. Restore previous `route-tracking.ts`, `analytics.ts`, and `ServiceCard.tsx` implementations.
+4. Re-run `npm run lint && npm test` to confirm green state before redeploying.
+

--- a/index.html
+++ b/index.html
@@ -10,6 +10,11 @@
           SUPABASE_URL: "https://gnkuikentdtnatazeriu.supabase.co",
           SUPABASE_ANON_KEY: "sb_publishable_Yu_Gv0Xfve27udk78CyT3w_qrbMR3Cn",
           REDDIT_PIXEL_ID: "a2_hisg7r10d2ta", // Default Reddit Pixel ID
+          LINKEDIN_SITE_PAGE_VIEW_ID: null,
+          LINKEDIN_LEAD_CONVERSION_ID: null,
+          LINKEDIN_SIGNUP_CONVERSION_ID: null,
+          LINKEDIN_PURCHASE_CONVERSION_ID: null,
+          LINKEDIN_ADD_TO_CART_CONVERSION_ID: null,
         };
         const config = Object.assign({}, defaultConfig, existing);
 
@@ -378,28 +383,6 @@
     </script>
     <!-- End LinkedIn Insight Tag (init) -->
 
-    <!-- LinkedIn Insight Tag helpers: SPA route tracking -->
-    <script>
-      (function() {
-        function onRoute() {
-          const path = (location.pathname || '').toLowerCase();
-          if (path.startsWith('/assessment')) {
-            window.lintrk && window.lintrk('track', { conversion_id: 7877778 });
-          }
-        }
-        onRoute();
-        ['pushState','replaceState'].forEach(method => {
-          const orig = history[method];
-          history[method] = function() {
-            const ret = orig.apply(this, arguments);
-            setTimeout(onRoute, 0);
-            return ret;
-          };
-        });
-        addEventListener('popstate', onRoute);
-      })();
-    </script>
-    <!-- End LinkedIn Insight Tag helpers -->
     <!-- Quora Pixel Code (Base) -->
     <script>
 !function(q,e,v,n,t,s){if(q.qp) return; n=q.qp=function(){n.qp?n.qp.apply(n,arguments):n.queue.push(arguments);}; n.queue=[];

--- a/src/lib/linkedin/track.ts
+++ b/src/lib/linkedin/track.ts
@@ -16,13 +16,33 @@ export interface LinkedInSignupResult {
   error?: string;
 }
 
-interface SendLinkedInSignupOptions {
-  conversionId: string;
+interface SendLinkedInSignupOptions extends SendLinkedInConversionOptions {
   email: string;
+}
+
+interface SendLinkedInConversionOptions {
+  conversionId: string;
+  email?: string;
   value?: number;
   currency?: string;
   alsoFireClient?: boolean;
   consentGranted?: boolean;
+}
+
+export interface LinkedInConversionConfig {
+  sitePageViewId?: string;
+  leadConversionId?: string;
+  signupConversionId?: string;
+  purchaseConversionId?: string;
+  addToCartConversionId?: string;
+}
+
+interface LinkedInEventOptions {
+  email?: string;
+  value?: number;
+  currency?: string;
+  consentGranted?: boolean;
+  alsoFireClient?: boolean;
 }
 
 const FUNCTIONS_ENDPOINT = "/functions/v1/linkedin-capi";
@@ -57,44 +77,115 @@ async function safeParseJson(response: Response): Promise<Record<string, unknown
   }
 }
 
-export async function sendLinkedInSignup({
+function readAppConfig(): Record<string, unknown> {
+  const source =
+    (typeof window !== "undefined" && (window as any).__APP_CONFIG__) ||
+    (typeof globalThis !== "undefined" && (globalThis as any).__APP_CONFIG__);
+  if (source && typeof source === "object") {
+    return source as Record<string, unknown>;
+  }
+  return {};
+}
+
+function toConversionId(value: unknown): string | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value);
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  }
+  return undefined;
+}
+
+function resolveConsent(consentOverride?: boolean): boolean {
+  if (typeof consentOverride === "boolean") {
+    return consentOverride;
+  }
+  if (typeof window === "undefined") {
+    return false;
+  }
+  try {
+    const consent = (window as any).__consent;
+    return Boolean(consent && typeof consent === "object" && consent.analytics === true);
+  } catch (_) {
+    return false;
+  }
+}
+
+function maybeFireClientPixel(conversionId: string | undefined): boolean {
+  if (!conversionId || typeof window === "undefined") {
+    return false;
+  }
+  if (typeof window.lintrk !== "function") {
+    return false;
+  }
+  const numericId = Number(conversionId);
+  const payload =
+    Number.isFinite(numericId) && !Number.isNaN(numericId)
+      ? { conversion_id: numericId }
+      : { conversion_id: conversionId };
+  try {
+    window.lintrk("track", payload as { conversion_id: number | string });
+    return true;
+  } catch (error) {
+    if (isDev()) {
+      console.warn("LI client pixel error", error);
+    }
+    return false;
+  }
+}
+
+export function getLinkedInConversionConfig(): LinkedInConversionConfig {
+  const config = readAppConfig();
+  return {
+    sitePageViewId: toConversionId(config.LINKEDIN_SITE_PAGE_VIEW_ID),
+    leadConversionId: toConversionId(config.LINKEDIN_LEAD_CONVERSION_ID),
+    signupConversionId: toConversionId(config.LINKEDIN_SIGNUP_CONVERSION_ID),
+    purchaseConversionId: toConversionId(config.LINKEDIN_PURCHASE_CONVERSION_ID),
+    addToCartConversionId: toConversionId(config.LINKEDIN_ADD_TO_CART_CONVERSION_ID),
+  };
+}
+
+async function sendLinkedInConversion({
   conversionId,
   email,
   value,
   currency,
   alsoFireClient = false,
-  consentGranted = true,
-}: SendLinkedInSignupOptions): Promise<LinkedInSignupResult> {
+  consentGranted,
+}: SendLinkedInConversionOptions): Promise<LinkedInSignupResult> {
+  const consent = resolveConsent(consentGranted);
   const eventId = ensureEventId();
 
-  if (alsoFireClient && typeof window !== "undefined" && typeof window.lintrk === "function") {
-    const numericId = Number(conversionId);
-    if (!Number.isNaN(numericId)) {
-      try {
-        window.lintrk("track", { conversion_id: numericId });
-      } catch (error) {
-        if (isDev()) {
-          console.warn("LI client pixel error", error);
-        }
-      }
-    }
+  if (!consent) {
+    return {
+      ok: false,
+      eventId,
+      code: "consent_blocked",
+      status: "dry_run",
+    };
+  }
+
+  if (alsoFireClient) {
+    maybeFireClientPixel(conversionId);
   }
 
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
   };
-  if (consentGranted === true) {
-    headers["x-consent-analytics"] = "true";
-  } else if (consentGranted === false) {
-    headers["x-consent-analytics"] = "false";
-  }
+
+  headers["x-consent-analytics"] = "true";
 
   const body: Record<string, unknown> = {
     conversionId,
-    email,
     eventId,
     userAgent: resolveUserAgent(),
   };
+
+  if (typeof email === "string" && email.trim().length > 0) {
+    body.email = email;
+  }
 
   if (typeof value === "number" && Number.isFinite(value)) {
     body.value = value;
@@ -152,14 +243,127 @@ export async function sendLinkedInSignup({
   }
 }
 
+export async function sendLinkedInSignup({
+  conversionId,
+  email,
+  value,
+  currency,
+  alsoFireClient = false,
+  consentGranted = true,
+}: SendLinkedInSignupOptions): Promise<LinkedInSignupResult> {
+  return sendLinkedInConversion({
+    conversionId,
+    email,
+    value,
+    currency,
+    alsoFireClient,
+    consentGranted,
+  });
+}
+
+export async function sendLinkedInLead(options: LinkedInEventOptions = {}): Promise<LinkedInSignupResult | undefined> {
+  const { leadConversionId } = getLinkedInConversionConfig();
+  if (!leadConversionId) {
+    return undefined;
+  }
+  const consent = resolveConsent(options.consentGranted);
+  if (!consent) {
+    return undefined;
+  }
+  return sendLinkedInConversion({
+    conversionId: leadConversionId,
+    email: options.email,
+    value: options.value,
+    currency: options.currency,
+    alsoFireClient: options.alsoFireClient ?? true,
+    consentGranted: consent,
+  });
+}
+
+export async function sendLinkedInSignupEvent(
+  options: LinkedInEventOptions & { email: string },
+): Promise<LinkedInSignupResult | undefined> {
+  const { signupConversionId } = getLinkedInConversionConfig();
+  if (!signupConversionId) {
+    return undefined;
+  }
+  const consent = resolveConsent(options.consentGranted);
+  if (!consent) {
+    return undefined;
+  }
+  return sendLinkedInConversion({
+    conversionId: signupConversionId,
+    email: options.email,
+    value: options.value,
+    currency: options.currency,
+    alsoFireClient: options.alsoFireClient ?? true,
+    consentGranted: consent,
+  });
+}
+
+export async function sendLinkedInPurchase(
+  options: LinkedInEventOptions & { value: number; currency: string; conversionId?: string },
+): Promise<LinkedInSignupResult | undefined> {
+  const { purchaseConversionId } = getLinkedInConversionConfig();
+  const conversionId = options.conversionId ?? purchaseConversionId;
+  if (!conversionId) {
+    return undefined;
+  }
+  const consent = resolveConsent(options.consentGranted);
+  if (!consent) {
+    return undefined;
+  }
+  return sendLinkedInConversion({
+    conversionId,
+    email: options.email,
+    value: options.value,
+    currency: options.currency,
+    alsoFireClient: options.alsoFireClient ?? true,
+    consentGranted: consent,
+  });
+}
+
+export async function sendLinkedInAddToCart(options: LinkedInEventOptions = {}): Promise<LinkedInSignupResult | undefined> {
+  const { addToCartConversionId } = getLinkedInConversionConfig();
+  if (!addToCartConversionId) {
+    return undefined;
+  }
+  const consent = resolveConsent(options.consentGranted);
+  if (!consent) {
+    return undefined;
+  }
+  return sendLinkedInConversion({
+    conversionId: addToCartConversionId,
+    email: options.email,
+    value: options.value,
+    currency: options.currency,
+    alsoFireClient: options.alsoFireClient ?? true,
+    consentGranted: consent,
+  });
+}
+
+export function sendLinkedInPageView(): boolean {
+  const { sitePageViewId } = getLinkedInConversionConfig();
+  if (!sitePageViewId) {
+    return false;
+  }
+  const consent = resolveConsent();
+  if (!consent) {
+    return false;
+  }
+  return maybeFireClientPixel(sitePageViewId);
+}
+
 export function testLinkedInSignup(conversionId: string, email: string) {
   return sendLinkedInSignup({ conversionId, email, alsoFireClient: false, consentGranted: true });
 }
 
 declare global {
   interface Window {
-    lintrk?: (command: string, payload: { conversion_id: number }) => void;
+    lintrk?: (command: string, payload: { conversion_id: number | string }) => void;
     liTest?: (conversionId: string, email: string) => Promise<LinkedInSignupResult>;
+    __consent?: { analytics?: boolean } | undefined;
+    __APP_CONFIG__?: Record<string, unknown>;
   }
 }
 
@@ -168,3 +372,5 @@ if (typeof window !== "undefined" && isDev()) {
     window.liTest = (conversionId: string, email: string) => testLinkedInSignup(conversionId, email);
   }
 }
+
+export { sendLinkedInConversion };

--- a/tests/serviceCard.test.tsx
+++ b/tests/serviceCard.test.tsx
@@ -35,10 +35,14 @@ test("renders Book button, triggers onSelect, and fires AddToCart", () => {
   const calls: Array<{ event: string; payload: Record<string, unknown> }> = [];
   (window as unknown as {
     fbTrack?: (eventName: string, payload?: Record<string, unknown>) => string;
+    rdtTrack?: (eventName: string, payload?: Record<string, unknown>) => string;
   }).fbTrack = (eventName, payload = {}) => {
     calls.push({ event: eventName, payload });
     return "evt";
   };
+  (window as unknown as {
+    rdtTrack?: (eventName: string, payload?: Record<string, unknown>) => string;
+  }).rdtTrack = () => "rdt";
 
   render(<ServiceCard service={svc} onSelect={onSelect} />);
 


### PR DESCRIPTION
## Summary
- add LinkedIn conversion config keys and drop legacy inline route tracker from the shell
- harden SPA route tracking to respect consent, broadcast page views, and emit a vendor status table
- extend analytics helpers and booking CTA to mirror LinkedIn/Twitter/Quora/Reddit events, plus document QA in docs/tracking-audit.md

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d0261fd938832a9b0ac9f5398a4cd1