### PR TITLE
Fix results caching and owner flow handling

### DIFF
--- a/src/features/results/queryKeys.ts
+++ b/src/features/results/queryKeys.ts
@@ -3,8 +3,8 @@ const baseKey = ['results'] as const;
 export const resultsQueryKeys = {
   all: baseKey,
   sessionScope: (sessionId: string) => [...baseKey, sessionId] as const,
-  session: (sessionId: string, shareToken?: string | null) =>
-    [...resultsQueryKeys.sessionScope(sessionId), shareToken ?? null] as const,
+  session: (sessionId: string, identity: string | null, version?: string | null) =>
+    [...resultsQueryKeys.sessionScope(sessionId), identity, version ?? null] as const,
 } as const;
 
 export type ResultsQueryKey = ReturnType<typeof resultsQueryKeys.session>;

--- a/supabase/functions/_shared/finalizeAssessmentCore.ts
+++ b/supabase/functions/_shared/finalizeAssessmentCore.ts
@@ -43,7 +43,7 @@ export interface FinalizeAssessmentDeps {
   getSession(sessionId: string): Promise<SessionRow | null>;
   upsertSession(sessionId: string, patch: Partial<SessionRow>): Promise<void>;
   generateShareToken(): string;
-  buildResultsUrl(baseUrl: string, sessionId: string, token: string): string;
+  buildResultsUrl(baseUrl: string, sessionId: string, token: string, version: string): string;
   now(): Date;
   log(payload: Record<string, unknown>): void;
 }
@@ -148,7 +148,7 @@ export async function finalizeAssessmentCore(
         updated_at: now.toISOString(),
       });
 
-      const resultsUrl = deps.buildResultsUrl(siteUrl, sessionId, shareToken);
+      const resultsUrl = deps.buildResultsUrl(siteUrl, sessionId, shareToken, RESULTS_VERSION);
       return {
         ok: true,
         profile: normalized,
@@ -187,7 +187,7 @@ export async function finalizeAssessmentCore(
       updated_at: now.toISOString(),
     });
 
-    const resultsUrl = deps.buildResultsUrl(siteUrl, sessionId, shareToken);
+    const resultsUrl = deps.buildResultsUrl(siteUrl, sessionId, shareToken, RESULTS_VERSION);
     return {
       ok: true,
       profile: normalized,

--- a/supabase/functions/_shared/results-link.ts
+++ b/supabase/functions/_shared/results-link.ts
@@ -1,5 +1,20 @@
-export function buildResultsLink(baseUrl: string, sessionId: string, token: string): string {
+export type BuildResultsLinkOptions = {
+  version?: string | null;
+};
+
+export function buildResultsLink(
+  baseUrl: string,
+  sessionId: string,
+  token: string,
+  options: BuildResultsLinkOptions = {},
+): string {
   const normalized = baseUrl.endsWith('/') ? baseUrl.slice(0, -1) : baseUrl;
-  return `${normalized}/results/${sessionId}?t=${token}`;
+  const params = new URLSearchParams();
+  params.set('t', token);
+  if (options.version && options.version.trim() !== '') {
+    params.set('sv', options.version.trim());
+  }
+  const query = params.toString();
+  return `${normalized}/results/${sessionId}?${query}`;
 }
 

--- a/supabase/functions/finalizeAssessment/index.ts
+++ b/supabase/functions/finalizeAssessment/index.ts
@@ -175,7 +175,8 @@ Deno.serve(async (req) => {
           getSession,
           upsertSession,
           generateShareToken,
-          buildResultsUrl: buildResultsLink,
+          buildResultsUrl: (baseUrl, sessionId, token, version) =>
+            buildResultsLink(baseUrl, sessionId, token, { version }),
           now: () => new Date(),
           log: (payload) => console.log(JSON.stringify(payload)),
         },

--- a/tests/resultsLink.test.ts
+++ b/tests/resultsLink.test.ts
@@ -11,3 +11,8 @@ test('buildResultsLink trims trailing slash', () => {
   const url = buildResultsLink('https://staging.prismassessment.com/', 's', 't');
   assert.equal(url, 'https://staging.prismassessment.com/results/s?t=t');
 });
+
+test('buildResultsLink adds scoring version when provided', () => {
+  const url = buildResultsLink('https://prismpersonality.com', 'sess', 'token', { version: 'v2.0' });
+  assert.equal(url, 'https://prismpersonality.com/results/sess?t=token&sv=v2.0');
+});


### PR DESCRIPTION
## Summary
- add scoring-version-aware results links and wire them through finalizeAssessment so redirects always carry sv metadata
- relax results fetch APIs to support owner JWT access while preserving token enforcement and logging
- rework the Results page query keys, auth session detection, and share-link rotation so TanStack Query invalidations are version-aware and owner flows render correctly

## Testing
- npm run typecheck
- npm test
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d028c239c0832ab2d48fb27402ec7c