### PR TITLE
Fix preview routing and tighten results access flows

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import { Toaster as Sonner } from "@/components/ui/sonner";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { Button } from "@/components/ui/button";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
+import { BrowserRouter, HashRouter, Routes, Route, Navigate } from "react-router-dom";
 import { AuthProvider } from "@/contexts/AuthContext";
 import Header from "@/components/Header";
 import Footer from "./components/Footer";
@@ -169,6 +169,26 @@ class ErrorBoundary extends React.Component<
 
 const queryClient = new QueryClient();
 
+const isLovablePreviewHost = (): boolean => {
+  if (typeof window === "undefined") {
+    return false;
+  }
+  const host = window.location.host.toLowerCase();
+  return host.includes("lovable.app") || host.includes("lovableproject.com");
+};
+
+const RouterProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  if (isLovablePreviewHost()) {
+    return <HashRouter>{children}</HashRouter>;
+  }
+
+  return (
+    <BrowserRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+      {children}
+    </BrowserRouter>
+  );
+};
+
 const App = () => (
   <ErrorBoundary>
     <QueryClientProvider client={queryClient}>
@@ -176,7 +196,7 @@ const App = () => (
         <TooltipProvider>
           <Toaster />
           <Sonner />
-          <BrowserRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
+          <RouterProvider>
             <div className="min-h-screen flex flex-col bg-background">
               <Header />
               <main className="flex-1 pt-16">
@@ -403,7 +423,7 @@ const App = () => (
               </main>
               <Footer />
             </div>
-          </BrowserRouter>
+          </RouterProvider>
         </TooltipProvider>
       </AuthProvider>
     </QueryClientProvider>

--- a/tests/results.page.rpc-contract.test.tsx
+++ b/tests/results.page.rpc-contract.test.tsx
@@ -182,7 +182,7 @@ test("Results page → missing token renders expired state without RPC", async (
   const queryClient = renderResultsRoute(["/results/sess-missing"]);
 
   await waitFor(() => {
-    assert.ok(screen.getByText(/This results link has expired or was rotated/i));
+    assert.ok(screen.getByText(/you.?re not signed in/i));
   });
   const edgeCalls = calls.filter((call) => call.url.endsWith("/get-results-by-session"));
   assert.equal(edgeCalls.length, 0);


### PR DESCRIPTION
## Summary
- switch preview builds to HashRouter whenever the app runs on a Lovable host so deep links work without rewrites
- expand the get-results-by-session CORS allowlist to cover Lovable domains and tighten header handling
- separate share-token and owner result fetch flows, add explicit unauthorized UI, and update contract tests

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d037404ad0832aa3c5a9467abdebfd