### PR TITLE
feat: wire quora pixel id config

### DIFF
--- a/docs/quora-pixel.md
+++ b/docs/quora-pixel.md
@@ -2,6 +2,7 @@
 
 ## Overview
 - Consent-gated Quora Pixel initialised from `index.html` via `qpTrack` helper.
+- Pixel ID sourced from runtime config (`window.__APP_CONFIG__.QUORA_PIXEL_ID`) or build env (`VITE_QUORA_PIXEL_ID`).
 - SPA-aware page view tracking pipes through `src/lib/route-tracking.ts` and `sendQuoraPageView` to keep URLs accurate.
 - Business events wired from `src/lib/analytics.ts`, `src/components/ServiceCard.tsx`, and `src/components/CalEmbed.tsx`.
 - Optional Conversions API edge function lives at `supabase/functions/quora-capi` and reuses client `conversion_id` values for dedupe.
@@ -25,7 +26,7 @@ Results routes remain suppressed unless `allowOnResults` is passed via `sendQuor
 - Helper auto-attaches `conversion_id` (UUID) and posts to `/functions/v1/quora-capi` for server dedupe when consent is granted.
 
 ## Conversions API
-- Edge function expects `QUORA_TOKEN` (bearer token) and optional `QUORA_PIXEL_ID` env vars.
+- Edge function expects `QUORA_TOKEN` (bearer token) and `QUORA_PIXEL_ID` env vars.
 - Request payload: `{ event_name, conversion_id, value?, currency?, email?, contents?, content_ids?, event_time?, client_ip?, user_agent? }`.
 - Email is normalised + SHA-256 hashed server-side via `_shared/crypto.ts`.
 - Retries (3x exponential backoff) on 429 / 5xx responses, returns `{ ok, status, eventId }`.

--- a/index.html
+++ b/index.html
@@ -5,7 +5,21 @@
     <meta http-equiv="Permissions-Policy" content="attribution-reporting=()" />
     <script>
       (function configureSupabase() {
-        const existing = window.__APP_CONFIG__ || {};
+        const existing = (function readExistingConfig() {
+          try {
+            const candidate = window.__APP_CONFIG__;
+            return candidate && typeof candidate === 'object' ? candidate : {};
+          } catch (_) {
+            return {};
+          }
+        })();
+
+        const rawEnvQuoraId = "%VITE_QUORA_PIXEL_ID%";
+        const envQuoraPixelId =
+          typeof rawEnvQuoraId === 'string' && rawEnvQuoraId && rawEnvQuoraId !== '%VITE_QUORA_PIXEL_ID%'
+            ? rawEnvQuoraId.trim()
+            : undefined;
+
         const defaultConfig = {
           SUPABASE_URL: "https://gnkuikentdtnatazeriu.supabase.co",
           SUPABASE_ANON_KEY: "sb_publishable_Yu_Gv0Xfve27udk78CyT3w_qrbMR3Cn",
@@ -15,8 +29,16 @@
           LINKEDIN_SIGNUP_CONVERSION_ID: null,
           LINKEDIN_PURCHASE_CONVERSION_ID: null,
           LINKEDIN_ADD_TO_CART_CONVERSION_ID: null,
+          QUORA_PIXEL_ID: undefined,
         };
+
         const config = Object.assign({}, defaultConfig, existing);
+        if (
+          (!config.QUORA_PIXEL_ID || typeof config.QUORA_PIXEL_ID !== 'string' || !config.QUORA_PIXEL_ID.trim()) &&
+          envQuoraPixelId
+        ) {
+          config.QUORA_PIXEL_ID = envQuoraPixelId;
+        }
 
         const normaliseUrl = (value) =>
           typeof value === 'string' ? value.replace(/\/+$/, '') : undefined;
@@ -390,11 +412,23 @@ t=document.createElement(e);t.async=!0;t.src=v; s=document.getElementsByTagName(
 }(window,'script','https://a.quora.com/qevents.js');
     </script>
     <noscript><img height="1" width="1" style="display:none"
-      src="https://q.quora.com/_/ad/3b47052b877e48a5b43d5f0d775d8e06/pixel?tag=ViewContent&noscript=1"/></noscript>
+      src="https://q.quora.com/_/ad/%VITE_QUORA_PIXEL_ID%/pixel?tag=ViewContent&noscript=1"/></noscript>
     <!-- End of Quora Pixel Code -->
     <script>
       (function(){
-        const PIXEL_ID = '3b47052b877e48a5b43d5f0d775d8e06';
+        function readPixelId(){
+          try {
+            const config = window.__APP_CONFIG__;
+            if (config && typeof config.QUORA_PIXEL_ID === 'string') {
+              const trimmed = config.QUORA_PIXEL_ID.trim();
+              if (trimmed) return trimmed;
+            }
+          } catch (_) {}
+          return undefined;
+        }
+
+        const configuredPixelId = readPixelId();
+        const PIXEL_ID = configuredPixelId || undefined;
         const RESULTS_RE = /\/results(\/|$)/i;
         const ALLOW_RESULTS_FLAG = '__allowResults';
         const DEBUG = /\bqdebug=1\b/.test(location.search);
@@ -409,6 +443,10 @@ t=document.createElement(e);t.async=!0;t.src=v; s=document.getElementsByTagName(
 
         function initQuora(email){
           try {
+            if (!PIXEL_ID) {
+              if (DEBUG) console.warn('[Quora] disabled – no QUORA_PIXEL_ID configured');
+              return;
+            }
             if (configured || !window.qp) return;
             if (email) { qp('init', PIXEL_ID, { email: email }); }
             else { qp('init', PIXEL_ID); }
@@ -420,6 +458,7 @@ t=document.createElement(e);t.async=!0;t.src=v; s=document.getElementsByTagName(
         // Defer init until consent is granted
         function tryConfigure(){
           if (configured) return true;
+          if (!PIXEL_ID) return false;
           if (!hasAnalyticsConsent() || typeof window.qp !== 'function') return false;
           // Optionally pass known email for advanced matching (hashed by Quora)
           const knownEmail = (window.__knownUser && window.__knownUser.email) || undefined;

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -2,6 +2,7 @@
 interface ImportMetaEnv {
   readonly SUPABASE_URL: string;
   readonly SUPABASE_ANON_KEY: string;
+  readonly VITE_QUORA_PIXEL_ID?: string;
 }
 interface ImportMeta {
   readonly env: ImportMetaEnv;

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,6 +1,46 @@
 const viteEnv = (typeof import.meta !== "undefined" ? (import.meta as any).env : undefined) ?? {};
 const nodeEnv = (typeof process !== "undefined" ? process.env : undefined) ?? {};
 
+const appConfig = (() => {
+  try {
+    if (typeof window !== "undefined" && window && typeof window === "object") {
+      const candidate = (window as any).__APP_CONFIG__;
+      if (candidate && typeof candidate === "object") {
+        return candidate as Record<string, unknown>;
+      }
+    }
+  } catch (_) {
+    // Ignore runtime access errors (e.g., window not defined)
+  }
+  try {
+    const candidate = (globalThis as any).__APP_CONFIG__;
+    if (candidate && typeof candidate === "object") {
+      return candidate as Record<string, unknown>;
+    }
+  } catch (_) {
+    // Ignore global access errors
+  }
+  return {} as Record<string, unknown>;
+})();
+
+const rawQuoraPixelId = (() => {
+  const fromVite = viteEnv.VITE_QUORA_PIXEL_ID as string | undefined;
+  if (typeof fromVite === "string" && fromVite.trim().length > 0) {
+    return fromVite.trim();
+  }
+  const fromNode = nodeEnv.VITE_QUORA_PIXEL_ID;
+  if (typeof fromNode === "string" && fromNode.trim().length > 0) {
+    return fromNode.trim();
+  }
+  const fromConfig = appConfig.QUORA_PIXEL_ID;
+  if (typeof fromConfig === "string" && fromConfig.trim().length > 0) {
+    return fromConfig.trim();
+  }
+  return undefined;
+})();
+
+export const QUORA_PIXEL_ID = rawQuoraPixelId;
+
 const previewSource =
   viteEnv.VITE_PREVIEW ??
   (viteEnv.VERCEL_ENV ?? nodeEnv.VERCEL_ENV ?? nodeEnv.VITE_PREVIEW ?? nodeEnv.NEXT_PUBLIC_VERCEL_ENV);

--- a/tests/quoraEnvConfig.test.ts
+++ b/tests/quoraEnvConfig.test.ts
@@ -1,0 +1,50 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+void test("QUORA_PIXEL_ID prefers env variables", async (t) => {
+  const originalEnv = process.env.VITE_QUORA_PIXEL_ID;
+  const originalConfig = (globalThis as any).__APP_CONFIG__;
+
+  process.env.VITE_QUORA_PIXEL_ID = "env-value";
+  delete (globalThis as any).__APP_CONFIG__;
+
+  t.after(() => {
+    if (originalEnv === undefined) {
+      delete process.env.VITE_QUORA_PIXEL_ID;
+    } else {
+      process.env.VITE_QUORA_PIXEL_ID = originalEnv;
+    }
+    if (originalConfig === undefined) {
+      delete (globalThis as any).__APP_CONFIG__;
+    } else {
+      (globalThis as any).__APP_CONFIG__ = originalConfig;
+    }
+  });
+
+  const module = await import(`../src/lib/env.ts?case=env-${Date.now()}`);
+  assert.equal(module.QUORA_PIXEL_ID, "env-value");
+});
+
+void test("QUORA_PIXEL_ID falls back to app config", async (t) => {
+  const originalEnv = process.env.VITE_QUORA_PIXEL_ID;
+  const originalConfig = (globalThis as any).__APP_CONFIG__;
+
+  delete process.env.VITE_QUORA_PIXEL_ID;
+  (globalThis as any).__APP_CONFIG__ = { QUORA_PIXEL_ID: "config-value" };
+
+  t.after(() => {
+    if (originalEnv === undefined) {
+      delete process.env.VITE_QUORA_PIXEL_ID;
+    } else {
+      process.env.VITE_QUORA_PIXEL_ID = originalEnv;
+    }
+    if (originalConfig === undefined) {
+      delete (globalThis as any).__APP_CONFIG__;
+    } else {
+      (globalThis as any).__APP_CONFIG__ = originalConfig;
+    }
+  });
+
+  const module = await import(`../src/lib/env.ts?case=config-${Date.now()}`);
+  assert.equal(module.QUORA_PIXEL_ID, "config-value");
+});

--- a/tests/run-tests.mjs
+++ b/tests/run-tests.mjs
@@ -30,6 +30,7 @@ const TEST_FILES = [
   'tests/linkedinTrack.test.ts',
   'tests/quoraCapiPayload.test.ts',
   'tests/quoraEvents.test.ts',
+  'tests/quoraEnvConfig.test.ts',
   'tests/getUserJwt.test.ts',
   'tests/classifyRpcError.test.ts',
   'tests/saveResponseIdempotent.test.ts',


### PR DESCRIPTION
## Summary
- surface QUORA pixel ID from env/app config during bootstrap
- guard Quora pixel init when no runtime ID is configured and expose helper constant
- tighten quora CAPI env handling and extend coverage for config resolution

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d03b5f9b7c832aace96ce2dd7a48f1