### PR TITLE
Fix preview routing, CORS headers, and rate limit metadata

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -169,16 +169,13 @@ class ErrorBoundary extends React.Component<
 
 const queryClient = new QueryClient();
 
-const isLovablePreviewHost = () => {
-  if (typeof window === "undefined") {
-    return false;
-  }
-  const host = window.location.host.toLowerCase();
-  return host.includes("lovable.app") || host.includes("lovableproject.com");
-};
+function isPreviewHost(hostname: string) {
+  const host = hostname.toLowerCase();
+  return host.includes("lovable.app") || host.includes("lovableproject.com") || host === "lovable.dev";
+}
 
 const RouterProvider = ({ children }: { children: React.ReactNode }) => {
-  if (isLovablePreviewHost()) {
+  if (typeof window !== "undefined" && isPreviewHost(window.location.hostname)) {
     return <HashRouter>{children}</HashRouter>;
   }
   return (

--- a/supabase/functions/finalizeAssessment/index.ts
+++ b/supabase/functions/finalizeAssessment/index.ts
@@ -149,7 +149,9 @@ Deno.serve(async (req) => {
   const rl = rateLimit(`finalize:${clientIp}`);
   if (!rl.allowed) {
     logger.warn("assessment.finalize.rate_limited", { ip: clientIp });
-    return json(origin, { status: "error", error: "rate_limited" }, 429);
+    const response = json(origin, { status: "error", error: "rate_limited" }, 429);
+    response.headers.set("Retry-After", String(rl.retryAfter ?? 60));
+    return response;
   }
   let sessionId: string | undefined;
   try {

--- a/supabase/functions/get-results-by-session/index.ts
+++ b/supabase/functions/get-results-by-session/index.ts
@@ -23,7 +23,9 @@ serve(async (req) => {
   const rl = rateLimit(`results:${clientIp}`);
   if (!rl.allowed) {
     logger.warn("results.rate_limited", { ip: clientIp });
-    return json(origin, { ok: false, error: "rate_limited" }, 429);
+    const response = json(origin, { ok: false, error: "rate_limited" }, 429);
+    response.headers.set("Retry-After", String(rl.retryAfter ?? 60));
+    return response;
   }
 
   if (req.method === "OPTIONS") {


### PR DESCRIPTION
## Summary
- update preview host detection to include lovable.dev and drive hash routing on preview hosts
- keep edge responses consistent with shared CORS helper and add Retry-After metadata when rate limited

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d050c12d48832aa81f8bce9a646e5b