### PR TITLE
Fix Reddit edge invocation and harden tracking payloads

### DIFF
--- a/index.html
+++ b/index.html
@@ -173,6 +173,19 @@
           requestInit.headers = headerBag;
           return fetch(target, requestInit);
         };
+
+        window.__invokeSupabaseEdge = function(path, init) {
+          const normalised = normaliseFunctionPath(String(path || ''));
+          try {
+            const invoker = window.__supabaseFunctionFetch;
+            if (typeof invoker === 'function') {
+              return invoker(normalised, init);
+            }
+          } catch (_err) {
+            // fall back to direct fetch when helper unavailable
+          }
+          return fetch(`/functions/v1/${normalised}`, init);
+        };
       })();
     </script>
     <script>
@@ -737,11 +750,9 @@
             keepalive: true,
           };
           try {
-            const invoke = window.__supabaseFunctionFetch;
-            if (typeof invoke === 'function') {
-              invoke('reddit-capi', requestInit).catch(() => {});
-            } else {
-              fetch('/functions/v1/reddit-capi', requestInit).catch(() => {});
+            const promise = window.__invokeSupabaseEdge && window.__invokeSupabaseEdge('reddit-capi', requestInit);
+            if (promise && typeof promise.catch === 'function') {
+              promise.catch(() => {});
             }
           } catch (e) {
             // no-op

--- a/src/lib/edge-functions.ts
+++ b/src/lib/edge-functions.ts
@@ -1,0 +1,59 @@
+const EDGE_PREFIX = 'functions/v1/';
+
+function normaliseEdgePath(path: string): string {
+  const raw = String(path ?? '');
+  const [maybePath, ...queryParts] = raw.split('?');
+  const trimmedPath = maybePath
+    .replace(/^\/+/, '')
+    .replace(new RegExp(`^${EDGE_PREFIX}`), '')
+    .replace(/^\/+/, '');
+  const query = queryParts.length > 0 ? `?${queryParts.join('?')}` : '';
+  return `${trimmedPath}${query}`;
+}
+
+function hasWindowInvoker(): boolean {
+  try {
+    return (
+      typeof window !== 'undefined' &&
+      typeof (window as typeof window & { __supabaseFunctionFetch?: unknown }).__supabaseFunctionFetch === 'function'
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function invokeEdge(path: string, init: RequestInit = {}): Promise<Response> {
+  const normalisedPath = normaliseEdgePath(path);
+  const headers: HeadersInit =
+    init.headers instanceof Headers
+      ? init.headers
+      : Array.isArray(init.headers)
+        ? [...init.headers]
+        : { ...(init.headers as Record<string, string> | undefined) };
+
+  const requestInit: RequestInit = {
+    ...init,
+    headers,
+  };
+
+  if (hasWindowInvoker()) {
+    try {
+      const invoker = (window as typeof window & {
+        __supabaseFunctionFetch?: (path: string, init: RequestInit) => Promise<Response>;
+      }).__supabaseFunctionFetch;
+      if (invoker) {
+        return invoker(normalisedPath, requestInit);
+      }
+    } catch {
+      // fall through to fetch
+    }
+  }
+
+  return fetch(`/functions/v1/${normalisedPath}`, requestInit);
+}
+
+export function invokeEdgeSilently(path: string, init: RequestInit = {}): void {
+  void invokeEdge(path, init).catch(() => {
+    // Swallow errors to avoid noisy consoles on optional tracking calls
+  });
+}

--- a/src/lib/reddit/client.ts
+++ b/src/lib/reddit/client.ts
@@ -1,6 +1,7 @@
 // Reddit Pixel + Conversions API client-side tracking utility
 
 import { IS_PREVIEW } from "@/lib/env";
+import { invokeEdge } from "@/lib/edge-functions";
 import { getConfiguredRedditPixelId } from "@/lib/reddit/config";
 
 export interface AttributionContext {
@@ -93,22 +94,23 @@ export async function trackRedditS2S(
       return;
     }
     
-    await fetch('/functions/v1/reddit-conversions', {
+    await invokeEdge('reddit-conversions', {
       method: 'POST',
-      headers: { 
-        'content-type': 'application/json',
-        'apikey': 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imdua3Vpa2VudGR0bmF0YXplcml1Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTM3MzI2MDQsImV4cCI6MjA2OTMwODYwNH0.wCk8ngoDqGW4bMIAjH5EttXsoBwdk4xnIViJZCezs-U'
+      headers: {
+        'content-type': 'application/json'
       },
-      body: JSON.stringify({ 
-        event_name, 
-        ctx, 
-        payload 
+      body: JSON.stringify({
+        event_name,
+        ctx,
+        payload
       }),
       keepalive: true
     });
   } catch (error) {
     // Never break UX - just log and continue silently
-    console.log('Reddit S2S tracking skipped:', error?.message || 'endpoint not available');
+    if (process.env.NODE_ENV === 'development') {
+      console.debug('Reddit S2S tracking skipped:', error);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- add a shared edge invocation helper that normalizes Supabase function paths and fallbacks to fetch
- update the Reddit tracking client and bootstrap script to use the helper instead of hard-coded fetch URLs
- keep Reddit CAPI logging quiet outside development to avoid noisy consoles when the edge function is unavailable

## Testing
- npm run lint
- npm run typecheck
- npm run test


------
https://chatgpt.com/codex/tasks/task_e_68d176f8cb68832a93e91388b2d0f529